### PR TITLE
BaseTools/build: Set MakefileName

### DIFF
--- a/edk2basetools/build/build.py
+++ b/edk2basetools/build/build.py
@@ -4,7 +4,7 @@
 #  Copyright (c) 2014, Hewlett-Packard Development Company, L.P.<BR>
 #  Copyright (c) 2007 - 2021, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2018, Hewlett Packard Enterprise Development, L.P.<BR>
-#  Copyright (c) 2020, ARM Limited. All rights reserved.<BR>
+#  Copyright (c) 2020 - 2021, ARM Limited. All rights reserved.<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -1307,6 +1307,9 @@ class Build():
         # run
         if Target == 'run':
             return True
+
+        # Fetch the MakeFileName.
+        self.MakeFileName = AutoGenObject.MakeFileName
 
         # build modules
         if BuildModule:


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3653

Running the following command:
  python3 build/build.py -a AARCH64 -t GCC5
  -p ArmPlatformPkg/ArmPlatformPkg.dsc -b DEBUG libraries
triggers the following error:
  make: *** Build/ArmPlatform/DEBUG_GCC5/AARCH64/MdePkg/Library/
  BasePcdLibNull/BasePcdLibNull: Is a directory.  Stop.

Indeed, MakefileName is set to en empty string. Setting MakefileName
resolves the error.

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Reviewed-by: Chris Jones <christopher.jones@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>