### PR TITLE
BaseTools: Remove Makefile/MakefileName fields

### DIFF
--- a/edk2basetools/AutoGen/ModuleAutoGen.py
+++ b/edk2basetools/AutoGen/ModuleAutoGen.py
@@ -254,7 +254,6 @@ class ModuleAutoGen(AutoGen):
         self.AutoGenDepSet = set()
         self.ReferenceModules = []
         self.ConstPcd                  = {}
-        self.Makefile         = None
         self.FileDependCache  = {}
 
     def __init_platform_info__(self):

--- a/edk2basetools/Workspace/BuildClassObject.py
+++ b/edk2basetools/Workspace/BuildClassObject.py
@@ -590,7 +590,6 @@ class PackageBuildClassObject(BuildData):
 # @var OutputDirectory:   To store value for OutputDirectory
 # @var FlashDefinition:   To store value for FlashDefinition
 # @var BuildNumber:       To store value for BuildNumber
-# @var MakefileName:      To store value for MakefileName
 # @var SkuIds:            To store value for SkuIds, it is a set structure as
 #                         { 'SkuName' : SkuId, '!include' : includefilename, ...}
 # @var Modules:           To store value for Modules, it is a list structure as
@@ -614,7 +613,6 @@ class PlatformBuildClassObject(BuildData):
         self.OutputDirectory         = ''
         self.FlashDefinition         = ''
         self.BuildNumber             = ''
-        self.MakefileName            = ''
 
         self.SkuIds                  = {}
         self.Modules                 = []

--- a/edk2basetools/build/build.py
+++ b/edk2basetools/build/build.py
@@ -2186,8 +2186,6 @@ class Build():
             Pa.CreateLibModuelDirs()
             # Fetch the MakeFileName.
             self.MakeFileName = Pa.MakeFileName
-            if not self.MakeFileName:
-                self.MakeFileName = Pa.MakeFile
 
             Pa.DataPipe.DataContainer = {"LibraryBuildDirectoryList":Pa.LibraryBuildDirectoryList}
             Pa.DataPipe.DataContainer = {"ModuleBuildDirectoryList":Pa.ModuleBuildDirectoryList}


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3653

The Makefile and MakefilName fields are never set/used. Remove them.
To check this, the following commands can be used:
- grep -rIn "\.Makefile"
- grep -rIn "\.MakefileName"

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Reviewed-by: Chris Jones <christopher.jones@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>