### PR TITLE
BaseTools: Remove hard-coded strings for target and tools_def

### DIFF
--- a/edk2basetools/GenFds/GenFds.py
+++ b/edk2basetools/GenFds/GenFds.py
@@ -20,7 +20,7 @@ from linecache import getlines
 from io import BytesIO
 
 import edk2basetools.Common.LongFilePathOs as os
-from edk2basetools.Common.TargetTxtClassObject import TargetTxtDict
+from edk2basetools.Common.TargetTxtClassObject import TargetTxtDict,gDefaultTargetTxtFile
 from edk2basetools.Common.DataType import *
 import edk2basetools.Common.GlobalData as GlobalData
 from edk2basetools.Common import EdkLogger
@@ -207,7 +207,7 @@ def GenFdsApi(FdsCommandDict, WorkSpaceDataBase=None):
         GenFdsGlobalVariable.ConfDir = ConfDirectoryPath
         if not GlobalData.gConfDirectory:
             GlobalData.gConfDirectory = GenFdsGlobalVariable.ConfDir
-        BuildConfigurationFile = os.path.normpath(os.path.join(ConfDirectoryPath, "target.txt"))
+        BuildConfigurationFile = os.path.normpath(os.path.join(ConfDirectoryPath, gDefaultTargetTxtFile))
         if os.path.isfile(BuildConfigurationFile) == True:
             # if no build target given in command line, get it from target.txt
             TargetObj = TargetTxtDict()

--- a/edk2basetools/GenFds/GenFdsGlobalVariable.py
+++ b/edk2basetools/GenFds/GenFdsGlobalVariable.py
@@ -24,7 +24,7 @@ from edk2basetools.Common import EdkLogger
 from edk2basetools.Common.Misc import SaveFileOnChange
 
 from edk2basetools.Common.TargetTxtClassObject import TargetTxtDict
-from edk2basetools.Common.ToolDefClassObject import ToolDefDict
+from edk2basetools.Common.ToolDefClassObject import ToolDefDict,gDefaultToolsDefFile
 from edk2basetools.AutoGen.BuildEngine import ToolBuildRule
 import edk2basetools.Common.DataType as DataType
 from edk2basetools.Common.Misc import PathClass,CreateDirectory
@@ -103,7 +103,7 @@ class GenFdsGlobalVariable:
         TargetObj = TargetTxtDict()
         ToolDefinitionFile = TargetObj.Target.TargetTxtDictionary[DataType.TAB_TAT_DEFINES_TOOL_CHAIN_CONF]
         if ToolDefinitionFile == '':
-            ToolDefinitionFile = "Conf/tools_def.txt"
+            ToolDefinitionFile =  os.path.join('Conf', gDefaultToolsDefFile)
         if os.path.isfile(ToolDefinitionFile):
             ToolDefObj = ToolDefDict((os.path.join(os.getenv("WORKSPACE"), "Conf")))
             ToolDefinition = ToolDefObj.ToolDef.ToolsDefTxtDatabase

--- a/edk2basetools/TargetTool/TargetTool.py
+++ b/edk2basetools/TargetTool/TargetTool.py
@@ -17,6 +17,7 @@ import edk2basetools.Common.BuildToolError as BuildToolError
 from edk2basetools.Common.DataType import *
 from edk2basetools.Common.BuildVersion import gBUILD_VERSION
 from edk2basetools.Common.LongFilePathSupport import OpenLongFilePath as open
+from edk2basetools.Common.TargetTxtClassObject import gDefaultTargetTxtFile
 
 # To Do 1.set clean, 2. add item, if the line is disabled.
 
@@ -25,7 +26,7 @@ class TargetTool():
         self.WorkSpace = os.path.normpath(os.getenv('WORKSPACE'))
         self.Opt       = opt
         self.Arg       = args[0]
-        self.FileName  = os.path.normpath(os.path.join(self.WorkSpace, 'Conf', 'target.txt'))
+        self.FileName  = os.path.normpath(os.path.join(self.WorkSpace, 'Conf', gDefaultTargetTxtFile))
         if os.path.isfile(self.FileName) == False:
             print("%s does not exist." % self.FileName)
             sys.exit(1)

--- a/edk2basetools/Workspace/DscBuildData.py
+++ b/edk2basetools/Workspace/DscBuildData.py
@@ -19,8 +19,8 @@ from edk2basetools.Common.Misc import *
 from types import *
 from edk2basetools.Common.Expression import *
 from edk2basetools.CommonDataClass.CommonClass import SkuInfoClass
-from edk2basetools.Common.TargetTxtClassObject import TargetTxtDict
-from edk2basetools.Common.ToolDefClassObject import ToolDefDict
+from edk2basetools.Common.TargetTxtClassObject import TargetTxtDict,gDefaultTargetTxtFile
+from edk2basetools.Common.ToolDefClassObject import ToolDefDict,gDefaultToolsDefFile
 from .MetaDataTable import *
 from .MetaFileTable import *
 from .MetaFileParser import *
@@ -3526,12 +3526,11 @@ class DscBuildData(PlatformBuildClassObject):
         self._ToolChainFamily = TAB_COMPILER_MSFT
         TargetObj = TargetTxtDict()
         TargetTxt = TargetObj.Target
-        BuildConfigurationFile = os.path.normpath(os.path.join(GlobalData.gConfDirectory, "target.txt"))
+        BuildConfigurationFile = os.path.normpath(os.path.join(GlobalData.gConfDirectory, gDefaultTargetTxtFile))
         if os.path.isfile(BuildConfigurationFile) == True:
             ToolDefinitionFile = TargetTxt.TargetTxtDictionary[DataType.TAB_TAT_DEFINES_TOOL_CHAIN_CONF]
             if ToolDefinitionFile == '':
-                ToolDefinitionFile = "tools_def.txt"
-                ToolDefinitionFile = os.path.normpath(mws.join(self.WorkspaceDir, 'Conf', ToolDefinitionFile))
+                ToolDefinitionFile = os.path.normpath(mws.join(self.WorkspaceDir, 'Conf', gDefaultToolsDefFile))
             if os.path.isfile(ToolDefinitionFile) == True:
                 ToolDefObj = ToolDefDict((os.path.join(os.getenv("WORKSPACE"), "Conf")))
                 ToolDefinition = ToolDefObj.ToolDef.ToolsDefTxtDatabase

--- a/edk2basetools/build/build.py
+++ b/edk2basetools/build/build.py
@@ -68,8 +68,6 @@ from edk2basetools.AutoGen.AutoGen import CalculatePriorityValue
 gSupportedTarget = ['all', 'genc', 'genmake', 'modules', 'libraries', 'fds', 'clean', 'cleanall', 'cleanlib', 'run']
 
 ## build configuration file
-gBuildConfiguration = "target.txt"
-gToolsDefinition = "tools_def.txt"
 
 TemporaryTablePattern = re.compile(r'^_\d+_\d+_[a-fA-F0-9]+$')
 TmpTableDict = {}


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3653

The "target.txt" and "tools_def.txt" filenames are hard-coded
at some places when global definitions are available at:
BaseTools/Source/Python/Common/TargetTxtClassObject.py:
DefaultTargetTxtFile
and
BaseTools/Source/Python/Common/ToolDefClassObject.py:
DefaultToolsDefFile

Use these global definitions instead.

Also remove the unused gBuildConfiguration and gToolsDefinition
variables from build.py

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>
Reviewed-by: Chris Jones <christopher.jones@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>