### PR TITLE
BaseTools: Change RealPath to AbsPath

### DIFF
--- a/edk2basetools/Ecc/EccMain.py
+++ b/edk2basetools/Ecc/EccMain.py
@@ -105,7 +105,7 @@ class Ecc(object):
 
     def InitDefaultConfigIni(self):
         paths = map(lambda p: os.path.join(p, 'Ecc', 'config.ini'), sys.path)
-        paths = (os.path.realpath('config.ini'),) + tuple(paths)
+        paths = (os.path.abspath('config.ini'),) + tuple(paths)
         for path in paths:
             if os.path.exists(path):
                 self.ConfigFile = path

--- a/edk2basetools/GenFds/FfsInfStatement.py
+++ b/edk2basetools/GenFds/FfsInfStatement.py
@@ -707,8 +707,8 @@ class FfsInfStatement(FfsInfStatementClassObject):
                                   FileName,
                                   'DEBUG'
                                   )
-        OutputPath = os.path.realpath(OutputPath)
-        DebugPath = os.path.realpath(DebugPath)
+        OutputPath = os.path.abspath(OutputPath)
+        DebugPath = os.path.abspath(DebugPath)
         return OutputPath, DebugPath
 
     ## __GenSimpleFileSection__() method

--- a/edk2basetools/GenFds/GenFds.py
+++ b/edk2basetools/GenFds/GenFds.py
@@ -153,7 +153,7 @@ def GenFdsApi(FdsCommandDict, WorkSpaceDataBase=None):
             FdfFilename = GenFdsGlobalVariable.ReplaceWorkspaceMacro(FdfFilename)
 
             if FdfFilename[0:2] == '..':
-                FdfFilename = os.path.realpath(FdfFilename)
+                FdfFilename = os.path.abspath(FdfFilename)
             if not os.path.isabs(FdfFilename):
                 FdfFilename = mws.join(GenFdsGlobalVariable.WorkSpaceDir, FdfFilename)
             if not os.path.exists(FdfFilename):
@@ -175,7 +175,7 @@ def GenFdsApi(FdsCommandDict, WorkSpaceDataBase=None):
             ActivePlatform = GenFdsGlobalVariable.ReplaceWorkspaceMacro(ActivePlatform)
 
             if ActivePlatform[0:2] == '..':
-                ActivePlatform = os.path.realpath(ActivePlatform)
+                ActivePlatform = os.path.abspath(ActivePlatform)
 
             if not os.path.isabs (ActivePlatform):
                 ActivePlatform = mws.join(GenFdsGlobalVariable.WorkSpaceDir, ActivePlatform)
@@ -299,7 +299,7 @@ def GenFdsApi(FdsCommandDict, WorkSpaceDataBase=None):
         for Key in GenFdsGlobalVariable.OutputDirDict:
             OutputDir = GenFdsGlobalVariable.OutputDirDict[Key]
             if OutputDir[0:2] == '..':
-                OutputDir = os.path.realpath(OutputDir)
+                OutputDir = os.path.abspath(OutputDir)
 
             if OutputDir[1] != ':':
                 OutputDir = os.path.join (GenFdsGlobalVariable.WorkSpaceDir, OutputDir)


### PR DESCRIPTION
Currently the realpath is used when parse modules, which shows the
path with a drive letter in build log. In Windows 'subst' comand is
used to associates a path with a drive letter, when use the mapped
drive letter for build, with realpath function the build log will
have different disk letter info which will cause confusion. In this
situation, if use adspath function to show the path info, it will keep
same letter with the mapped drive letter, which avoids confusion.
This patch modifies the realpath to abspath.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Bob Feng <bob.c.feng@Intel.com>