### PR TITLE
Fix wrong variable header size and Fix the bug of --cmd-len build option

### DIFF
--- a/edk2basetools/AutoGen/AutoGenWorker.py
+++ b/edk2basetools/AutoGen/AutoGenWorker.py
@@ -198,6 +198,7 @@ class AutoGenWorkerInProcess(mp.Process):
             self.Wa._SrcTimeStamp = self.data_pipe.Get("Workspace_timestamp")
             GlobalData.gGlobalDefines = self.data_pipe.Get("G_defines")
             GlobalData.gCommandLineDefines = self.data_pipe.Get("CL_defines")
+            GlobalData.gCommandMaxLength = self.data_pipe.Get('gCommandMaxLength')
             os.environ._data = self.data_pipe.Get("Env_Var")
             GlobalData.gWorkspace = workspacedir
             GlobalData.gDisableIncludePathCheck = False

--- a/edk2basetools/AutoGen/DataPipe.py
+++ b/edk2basetools/AutoGen/DataPipe.py
@@ -148,6 +148,8 @@ class MemoryDataPipe(DataPipe):
 
         self.DataContainer = {"CL_defines": GlobalData.gCommandLineDefines}
 
+        self.DataContainer = {"gCommandMaxLength": GlobalData.gCommandMaxLength}
+
         self.DataContainer = {"Env_Var": {k:v for k, v in os.environ.items()}}
 
         self.DataContainer = {"PackageList": [(dec.MetaFile,dec.Arch) for dec in PlatformInfo.PackageList]}

--- a/edk2basetools/AutoGen/GenVar.py
+++ b/edk2basetools/AutoGen/GenVar.py
@@ -20,6 +20,7 @@ import edk2basetools.Common.GlobalData as GlobalData
 var_info = collections.namedtuple("uefi_var", "pcdindex,pcdname,defaultstoragename,skuname,var_name, var_guid, var_offset,var_attribute,pcd_default_value, default_value, data_type,PcdDscLine,StructurePcd")
 NvStorageHeaderSize = 28
 VariableHeaderSize = 32
+AuthenticatedVariableHeaderSize = 60
 
 class VariableMgr(object):
     def __init__(self, DefaultStoreMap, SkuIdMap):
@@ -171,7 +172,10 @@ class VariableMgr(object):
             DataBuffer = VariableMgr.AlignData(var_name_buffer + default_data)
 
             data_size = len(DataBuffer)
-            offset += VariableHeaderSize + len(default_info.var_name.split(","))
+            if GlobalData.gCommandLineDefines.get(TAB_DSC_DEFINES_VPD_AUTHENTICATED_VARIABLE_STORE,"FALSE").upper() == "TRUE":
+                offset += AuthenticatedVariableHeaderSize + len(default_info.var_name.split(","))
+            else:
+                offset += VariableHeaderSize + len(default_info.var_name.split(","))
             var_data_offset[default_info.pcdindex] = offset
             offset += data_size - len(default_info.var_name.split(","))
             if GlobalData.gCommandLineDefines.get(TAB_DSC_DEFINES_VPD_AUTHENTICATED_VARIABLE_STORE,"FALSE").upper() == "TRUE":


### PR DESCRIPTION
SHA-1: 266ae79854ea44ec9b03ff4c9e8e4e7ba2f09fbd

BaseTools: Fix the bug of --cmd-len build option

currently the --cmd-len build option does not work.
This patch is going to fix this bug.

SHA-1: df66bccf6486bb19a48f0582f7d7ad1643841342

* BaseTools: Fix wrong variable header size

There are two type variable header and their size are different,
need to use matched size when calculating offset info, otherwise
it'll destroy other variables content when patching.



