### PR TITLE
BaseTools: Remove the redundant __FLEXIBLE_SIZE from PcdValueInit.c

### DIFF
--- a/edk2basetools/Workspace/DscBuildData.py
+++ b/edk2basetools/Workspace/DscBuildData.py
@@ -1876,6 +1876,7 @@ class DscBuildData(PlatformBuildClassObject):
                     while '[' in FieldName and not Pcd.IsArray():
                         FieldName = FieldName.rsplit('[', 1)[0]
                         CApp = CApp + '  __FLEXIBLE_SIZE(*Size, %s, %s, %d); // From %s Line %d Value %s\n' % (Pcd.DatumType, FieldName.strip("."), Array_Index + 1, FieldList[FieldName_ori][1], FieldList[FieldName_ori][2], FieldList[FieldName_ori][0])
+        flexisbale_size_statement_cache = set()
         for skuname in Pcd.SkuOverrideValues:
             if skuname == TAB_COMMON:
                 continue
@@ -1888,6 +1889,10 @@ class DscBuildData(PlatformBuildClassObject):
                         if not FieldList:
                             continue
                         for FieldName in FieldList:
+                            fieldinfo = tuple(FieldList[FieldName])
+                            if fieldinfo in flexisbale_size_statement_cache:
+                                continue
+                            flexisbale_size_statement_cache.add(fieldinfo)
                             FieldName = "." + FieldName
                             IsArray = _IsFieldValueAnArray(FieldList[FieldName.strip(".")][0])
                             if IsArray and not (FieldList[FieldName.strip(".")][0].startswith('{GUID') and FieldList[FieldName.strip(".")][0].endswith('}')):


### PR DESCRIPTION
For the multiple SKU case, basetools generates multiple redundant
__FLEXIBLE_SIZE statement that is from the same line in dsc file.

This behavior causes the generated PcdValueInit.c file to have huge size,
and the compilation time is very long.

This patch is going to fix this issue.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Reviewed-by: Yuwei Chen <yuwei.chen@intel.com>