### PR TITLE
BaseTools:Support decimal version number in ECC check

### DIFF
--- a/edk2basetools/Ecc/MetaFileWorkspace/MetaFileParser.py
+++ b/edk2basetools/Ecc/MetaFileWorkspace/MetaFileParser.py
@@ -31,6 +31,10 @@ from edk2basetools.GenFds.FdfParser import FdfParser
 from edk2basetools.Common.LongFilePathSupport import OpenLongFilePath as open
 from edk2basetools.Common.LongFilePathSupport import CodecOpenLongFilePath
 
+## RegEx for finding file versions
+hexVersionPattern = re.compile(r'0[xX][\da-f-A-F]{5,8}')
+decVersionPattern = re.compile(r'\d+\.\d+')
+
 ## A decorator used to parse macro definition
 def ParseMacro(Parser):
     def MacroParser(self):
@@ -331,11 +335,19 @@ class MetaFileParser(object):
         Name, Value = self._ValueList[1], self._ValueList[2]
         # Sometimes, we need to make differences between EDK and EDK2 modules
         if Name == 'INF_VERSION':
-            try:
+            if hexVersionPattern.match(Value):
                 self._Version = int(Value, 0)
-            except:
+            elif decVersionPattern.match(Value):
+                ValueList = Value.split('.')
+                Major = int(ValueList[0], 0)
+                Minor = int(ValueList[1], 0)
+                if Major > 0xffff or Minor > 0xffff:
+                    EdkLogger.error('Parser', FORMAT_INVALID, "Invalid version number",
+                                    ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
+                self._Version = int('0x{0:04x}{1:04x}'.format(Major, Minor), 0)
+            else:
                 EdkLogger.error('Parser', FORMAT_INVALID, "Invalid version number",
-                                ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex+1)
+                                ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
         elif Name == 'MODULE_UNI_FILE':
             UniFile = os.path.join(os.path.dirname(self.MetaFile), Value)
             if os.path.exists(UniFile):


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3872

When doing ecc inf version check, the decimal type version number
like 1.27 is treated as invalid version.
So the code should be updated to support decimal type version number.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Signed-off-by: Wenyi Xie <xiewenyi2@huawei.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>