### PR TITLE
BaseTools: Migrate project to argparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build.
 /test.junit.xml
 flake8.err.log
 /.eggs
+/.venv

--- a/edk2basetools/AutoGen/GenDepex.py
+++ b/edk2basetools/AutoGen/GenDepex.py
@@ -376,9 +376,9 @@ class DependencyExpression:
 
 
 versionNumber = ("0.04" + " " + gBUILD_VERSION)
-__version__ = "%prog Version " + versionNumber
+__version__ = "%(prog)s Version " + versionNumber
 __copyright__ = "Copyright (c) 2007-2018, Intel Corporation  All rights reserved."
-__usage__ = "%prog [options] [dependency_expression_file]"
+__usage__ = "%(prog)s [options] [dependency_expression_file]"
 
 # Parse command line options
 #
@@ -387,7 +387,7 @@ __usage__ = "%prog [options] [dependency_expression_file]"
 
 
 def GetOptions():
-    Parser = ArgumentParser(description=__copyright__)
+    Parser = ArgumentParser(description=__copyright__, usage=__usage__)
 
     Parser.add_argument("DependencyExpressionFile", metavar="DEPENDENCY_EXPRESSION_FILE",
                         nargs="?", type=str, help="Dependency Expression File")

--- a/edk2basetools/AutoGen/GenDepex.py
+++ b/edk2basetools/AutoGen/GenDepex.py
@@ -1,10 +1,10 @@
-## @file
+# @file
 # This file is used to generate DEPEX file for module's dependency expression
 #
 # Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 
-## Import Modules
+# Import Modules
 #
 import sys
 import edk2basetools.Common.LongFilePathOs as os
@@ -21,96 +21,100 @@ from edk2basetools.Common.Misc import GuidStringToGuidStructureString
 from edk2basetools.Common import EdkLogger as EdkLogger
 from edk2basetools.Common.BuildVersion import gBUILD_VERSION
 from edk2basetools.Common.DataType import *
+from argparse import ArgumentParser
 
-## Regular expression for matching "DEPENDENCY_START ... DEPENDENCY_END"
+# Regular expression for matching "DEPENDENCY_START ... DEPENDENCY_END"
 gStartClosePattern = re.compile(".*DEPENDENCY_START(.+)DEPENDENCY_END.*", re.S)
 
-## Mapping between module type and EFI phase
+# Mapping between module type and EFI phase
 gType2Phase = {
-    SUP_MODULE_BASE              :   None,
-    SUP_MODULE_SEC               :   "PEI",
-    SUP_MODULE_PEI_CORE          :   "PEI",
-    SUP_MODULE_PEIM              :   "PEI",
-    SUP_MODULE_DXE_CORE          :   "DXE",
-    SUP_MODULE_DXE_DRIVER        :   "DXE",
-    SUP_MODULE_DXE_SMM_DRIVER    :   "DXE",
-    SUP_MODULE_DXE_RUNTIME_DRIVER:   "DXE",
-    SUP_MODULE_DXE_SAL_DRIVER    :   "DXE",
-    SUP_MODULE_UEFI_DRIVER       :   "DXE",
-    SUP_MODULE_UEFI_APPLICATION  :   "DXE",
-    SUP_MODULE_SMM_CORE          :   "DXE",
-    SUP_MODULE_MM_STANDALONE     :   "MM",
-    SUP_MODULE_MM_CORE_STANDALONE :  "MM",
+    SUP_MODULE_BASE: None,
+    SUP_MODULE_SEC: "PEI",
+    SUP_MODULE_PEI_CORE: "PEI",
+    SUP_MODULE_PEIM: "PEI",
+    SUP_MODULE_DXE_CORE: "DXE",
+    SUP_MODULE_DXE_DRIVER: "DXE",
+    SUP_MODULE_DXE_SMM_DRIVER: "DXE",
+    SUP_MODULE_DXE_RUNTIME_DRIVER: "DXE",
+    SUP_MODULE_DXE_SAL_DRIVER: "DXE",
+    SUP_MODULE_UEFI_DRIVER: "DXE",
+    SUP_MODULE_UEFI_APPLICATION: "DXE",
+    SUP_MODULE_SMM_CORE: "DXE",
+    SUP_MODULE_MM_STANDALONE: "MM",
+    SUP_MODULE_MM_CORE_STANDALONE: "MM",
 }
 
-## Convert dependency expression string into EFI internal representation
+# Convert dependency expression string into EFI internal representation
 #
 #   DependencyExpression class is used to parse dependency expression string and
 # convert it into its binary form.
 #
+
+
 class DependencyExpression:
 
     ArchProtocols = {
-                        '665e3ff6-46cc-11d4-9a38-0090273fc14d',     #   'gEfiBdsArchProtocolGuid'
-                        '26baccb1-6f42-11d4-bce7-0080c73c8881',     #   'gEfiCpuArchProtocolGuid'
-                        '26baccb2-6f42-11d4-bce7-0080c73c8881',     #   'gEfiMetronomeArchProtocolGuid'
-                        '1da97072-bddc-4b30-99f1-72a0b56fff2a',     #   'gEfiMonotonicCounterArchProtocolGuid'
-                        '27cfac87-46cc-11d4-9a38-0090273fc14d',     #   'gEfiRealTimeClockArchProtocolGuid'
-                        '27cfac88-46cc-11d4-9a38-0090273fc14d',     #   'gEfiResetArchProtocolGuid'
-                        'b7dfb4e1-052f-449f-87be-9818fc91b733',     #   'gEfiRuntimeArchProtocolGuid'
-                        'a46423e3-4617-49f1-b9ff-d1bfa9115839',     #   'gEfiSecurityArchProtocolGuid'
-                        '26baccb3-6f42-11d4-bce7-0080c73c8881',     #   'gEfiTimerArchProtocolGuid'
-                        '6441f818-6362-4e44-b570-7dba31dd2453',     #   'gEfiVariableWriteArchProtocolGuid'
-                        '1e5668e2-8481-11d4-bcf1-0080c73c8881',     #   'gEfiVariableArchProtocolGuid'
-                        '665e3ff5-46cc-11d4-9a38-0090273fc14d'      #   'gEfiWatchdogTimerArchProtocolGuid'
-                    }
+        '665e3ff6-46cc-11d4-9a38-0090273fc14d',  # 'gEfiBdsArchProtocolGuid'
+        '26baccb1-6f42-11d4-bce7-0080c73c8881',  # 'gEfiCpuArchProtocolGuid'
+        '26baccb2-6f42-11d4-bce7-0080c73c8881',  # 'gEfiMetronomeArchProtocolGuid'
+        '1da97072-bddc-4b30-99f1-72a0b56fff2a',  # 'gEfiMonotonicCounterArchProtocolGuid'
+        '27cfac87-46cc-11d4-9a38-0090273fc14d',  # 'gEfiRealTimeClockArchProtocolGuid'
+        '27cfac88-46cc-11d4-9a38-0090273fc14d',  # 'gEfiResetArchProtocolGuid'
+        'b7dfb4e1-052f-449f-87be-9818fc91b733',  # 'gEfiRuntimeArchProtocolGuid'
+        'a46423e3-4617-49f1-b9ff-d1bfa9115839',  # 'gEfiSecurityArchProtocolGuid'
+        '26baccb3-6f42-11d4-bce7-0080c73c8881',  # 'gEfiTimerArchProtocolGuid'
+        '6441f818-6362-4e44-b570-7dba31dd2453',  # 'gEfiVariableWriteArchProtocolGuid'
+        '1e5668e2-8481-11d4-bcf1-0080c73c8881',  # 'gEfiVariableArchProtocolGuid'
+        '665e3ff5-46cc-11d4-9a38-0090273fc14d'  # 'gEfiWatchdogTimerArchProtocolGuid'
+    }
 
     OpcodePriority = {
-        DEPEX_OPCODE_AND   :   1,
-        DEPEX_OPCODE_OR    :   1,
-        DEPEX_OPCODE_NOT   :   2,
+        DEPEX_OPCODE_AND: 1,
+        DEPEX_OPCODE_OR: 1,
+        DEPEX_OPCODE_NOT: 2,
     }
 
     Opcode = {
-        "PEI"   : {
-            DEPEX_OPCODE_PUSH  :   0x02,
-            DEPEX_OPCODE_AND   :   0x03,
-            DEPEX_OPCODE_OR    :   0x04,
-            DEPEX_OPCODE_NOT   :   0x05,
-            DEPEX_OPCODE_TRUE  :   0x06,
-            DEPEX_OPCODE_FALSE :   0x07,
-            DEPEX_OPCODE_END   :   0x08
+        "PEI": {
+            DEPEX_OPCODE_PUSH: 0x02,
+            DEPEX_OPCODE_AND: 0x03,
+            DEPEX_OPCODE_OR: 0x04,
+            DEPEX_OPCODE_NOT: 0x05,
+            DEPEX_OPCODE_TRUE: 0x06,
+            DEPEX_OPCODE_FALSE: 0x07,
+            DEPEX_OPCODE_END: 0x08
         },
 
-        "DXE"   : {
-            DEPEX_OPCODE_BEFORE:   0x00,
-            DEPEX_OPCODE_AFTER :   0x01,
-            DEPEX_OPCODE_PUSH  :   0x02,
-            DEPEX_OPCODE_AND   :   0x03,
-            DEPEX_OPCODE_OR    :   0x04,
-            DEPEX_OPCODE_NOT   :   0x05,
-            DEPEX_OPCODE_TRUE  :   0x06,
-            DEPEX_OPCODE_FALSE :   0x07,
-            DEPEX_OPCODE_END   :   0x08,
-            DEPEX_OPCODE_SOR   :   0x09
+        "DXE": {
+            DEPEX_OPCODE_BEFORE: 0x00,
+            DEPEX_OPCODE_AFTER: 0x01,
+            DEPEX_OPCODE_PUSH: 0x02,
+            DEPEX_OPCODE_AND: 0x03,
+            DEPEX_OPCODE_OR: 0x04,
+            DEPEX_OPCODE_NOT: 0x05,
+            DEPEX_OPCODE_TRUE: 0x06,
+            DEPEX_OPCODE_FALSE: 0x07,
+            DEPEX_OPCODE_END: 0x08,
+            DEPEX_OPCODE_SOR: 0x09
         },
 
-        "MM"   : {
-            DEPEX_OPCODE_BEFORE:   0x00,
-            DEPEX_OPCODE_AFTER :   0x01,
-            DEPEX_OPCODE_PUSH  :   0x02,
-            DEPEX_OPCODE_AND   :   0x03,
-            DEPEX_OPCODE_OR    :   0x04,
-            DEPEX_OPCODE_NOT   :   0x05,
-            DEPEX_OPCODE_TRUE  :   0x06,
-            DEPEX_OPCODE_FALSE :   0x07,
-            DEPEX_OPCODE_END   :   0x08,
-            DEPEX_OPCODE_SOR   :   0x09
+        "MM": {
+            DEPEX_OPCODE_BEFORE: 0x00,
+            DEPEX_OPCODE_AFTER: 0x01,
+            DEPEX_OPCODE_PUSH: 0x02,
+            DEPEX_OPCODE_AND: 0x03,
+            DEPEX_OPCODE_OR: 0x04,
+            DEPEX_OPCODE_NOT: 0x05,
+            DEPEX_OPCODE_TRUE: 0x06,
+            DEPEX_OPCODE_FALSE: 0x07,
+            DEPEX_OPCODE_END: 0x08,
+            DEPEX_OPCODE_SOR: 0x09
         }
     }
 
     # all supported op codes and operands
-    SupportedOpcode = [DEPEX_OPCODE_BEFORE, DEPEX_OPCODE_AFTER, DEPEX_OPCODE_PUSH, DEPEX_OPCODE_AND, DEPEX_OPCODE_OR, DEPEX_OPCODE_NOT, DEPEX_OPCODE_END, DEPEX_OPCODE_SOR]
+    SupportedOpcode = [DEPEX_OPCODE_BEFORE, DEPEX_OPCODE_AFTER, DEPEX_OPCODE_PUSH,
+                       DEPEX_OPCODE_AND, DEPEX_OPCODE_OR, DEPEX_OPCODE_NOT, DEPEX_OPCODE_END, DEPEX_OPCODE_SOR]
     SupportedOperand = [DEPEX_OPCODE_TRUE, DEPEX_OPCODE_FALSE]
 
     OpcodeWithSingleOperand = [DEPEX_OPCODE_NOT, DEPEX_OPCODE_BEFORE, DEPEX_OPCODE_AFTER]
@@ -128,7 +132,7 @@ class DependencyExpression:
     #
     TokenPattern = re.compile("(\(|\)|\{[^{}]+\{?[^{}]+\}?[ ]*\}|\w+)")
 
-    ## Constructor
+    # Constructor
     #
     #   @param  Expression  The list or string of dependency expression
     #   @param  ModuleType  The type of the module using the dependency expression
@@ -166,11 +170,11 @@ class DependencyExpression:
                 WellForm += ' ' + Token
         return WellForm
 
-    ## Split the expression string into token list
+    # Split the expression string into token list
     def GetExpressionTokenList(self):
         self.TokenList = self.TokenPattern.findall(self.ExpressionString)
 
-    ## Convert token list into postfix notation
+    # Convert token list into postfix notation
     def GetPostfixNotation(self):
         Stack = []
         LastToken = ''
@@ -198,8 +202,8 @@ class DependencyExpression:
                         EdkLogger.error("GenDepex", PARSER_ERROR, "Invalid dependency expression: missing operator before NOT",
                                         ExtraData="Near %s" % LastToken)
                 elif LastToken in self.SupportedOpcode + ['(', '', None]:
-                        EdkLogger.error("GenDepex", PARSER_ERROR, "Invalid dependency expression: missing operand before " + Token,
-                                        ExtraData="Near %s" % LastToken)
+                    EdkLogger.error("GenDepex", PARSER_ERROR, "Invalid dependency expression: missing operand before " + Token,
+                                    ExtraData="Near %s" % LastToken)
 
                 while len(Stack) > 0:
                     if Stack[-1] == "(" or self.OpcodePriority[Token] >= self.OpcodePriority[Stack[-1]]:
@@ -237,7 +241,7 @@ class DependencyExpression:
         if self.PostfixNotation[-1] != DEPEX_OPCODE_END:
             self.PostfixNotation.append(DEPEX_OPCODE_END)
 
-    ## Validate the dependency expression
+    # Validate the dependency expression
     def ValidateOpcode(self):
         for Op in self.AboveAllOpcode:
             if Op in self.PostfixNotation:
@@ -265,14 +269,14 @@ class DependencyExpression:
             EdkLogger.error("GenDepex", PARSER_ERROR, "Extra expressions after END",
                             ExtraData=str(self))
 
-    ## Simply optimize the dependency expression by removing duplicated operands
+    # Simply optimize the dependency expression by removing duplicated operands
     def Optimize(self):
         OpcodeSet = set(self.OpcodeList)
         # if there are isn't one in the set, return
         if len(OpcodeSet) != 1:
-          return
+            return
         Op = OpcodeSet.pop()
-        #if Op isn't either OR or AND, return
+        # if Op isn't either OR or AND, return
         if Op not in [DEPEX_OPCODE_AND, DEPEX_OPCODE_OR]:
             return
         NewOperand = []
@@ -319,13 +323,13 @@ class DependencyExpression:
         self.PostfixNotation = []
         self.GetPostfixNotation()
 
-
-    ## Convert a GUID value in C structure format into its binary form
+    # Convert a GUID value in C structure format into its binary form
     #
     #   @param  Guid    The GUID value in C structure format
     #
     #   @retval array   The byte array representing the GUID value
     #
+
     def GetGuidValue(self, Guid):
         GuidValueString = Guid.replace("{", "").replace("}", "").replace(" ", "")
         GuidValueList = GuidValueString.split(",")
@@ -337,7 +341,7 @@ class DependencyExpression:
             EdkLogger.error("GenDepex", PARSER_ERROR, "Invalid GUID value string or opcode: %s" % Guid)
         return pack("1I2H8B", *(int(value, 16) for value in GuidValueList))
 
-    ## Save the binary form of dependency expression in file
+    # Save the binary form of dependency expression in file
     #
     #   @param  File    The path of file. If None is given, put the data on console
     #
@@ -370,88 +374,95 @@ class DependencyExpression:
         Buffer.close()
         return FileChangeFlag
 
+
 versionNumber = ("0.04" + " " + gBUILD_VERSION)
 __version__ = "%prog Version " + versionNumber
 __copyright__ = "Copyright (c) 2007-2018, Intel Corporation  All rights reserved."
 __usage__ = "%prog [options] [dependency_expression_file]"
 
-## Parse command line options
+# Parse command line options
 #
 #   @retval OptionParser
 #
+
+
 def GetOptions():
-    from optparse import OptionParser
+    Parser = ArgumentParser(description=__copyright__)
 
-    Parser = OptionParser(description=__copyright__, version=__version__, usage=__usage__)
+    Parser.add_argument("DependencyExpressionFile", metavar="DEPENDENCY_EXPRESSION_FILE",
+                        nargs="?", type=str, help="Dependency Expression File")
+    Parser.add_argument('--version', action='version', version=__version__)
+    Parser.add_argument("-o", "--output", dest="OutputFile", metavar="FILE", type=str,
+                        help="Specify the name of depex file to be generated")
 
-    Parser.add_option("-o", "--output", dest="OutputFile", default=None, metavar="FILE",
-                      help="Specify the name of depex file to be generated")
-    Parser.add_option("-t", "--module-type", dest="ModuleType", default=None,
-                      help="The type of module for which the dependency expression serves")
-    Parser.add_option("-e", "--dependency-expression", dest="Expression", default="",
-                      help="The string of dependency expression. If this option presents, the input file will be ignored.")
-    Parser.add_option("-m", "--optimize", dest="Optimize", default=False, action="store_true",
-                      help="Do some simple optimization on the expression.")
-    Parser.add_option("-v", "--verbose", dest="verbose", default=False, action="store_true",
-                      help="build with verbose information")
-    Parser.add_option("-d", "--debug", action="store", type="int", help="Enable debug messages at specified level.")
-    Parser.add_option("-q", "--quiet", dest="quiet", default=False, action="store_true",
-                      help="build with little information")
+    # Maybe Convert to Positional Argument
+    Parser.add_argument("-t", "--module-type", dest="ModuleType", type=str, required=True,
+                        help="The type of module for which the dependency expression serves")
+    Parser.add_argument("-e", "--dependency-expression", dest="Expression", default="", type=str,
+                        help="The string of dependency expression. If this option presents, the input file will be ignored.")
+    Parser.add_argument("-m", "--optimize", dest="Optimize", action="store_true",
+                        help="Do some simple optimization on the expression.")
+    Parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
+                        help="build with verbose information")
+    Parser.add_argument("-d", "--debug", action="store", type=int, help="Enable debug messages at specified level.")
+    Parser.add_argument("-q", "--quiet", dest="quiet", action="store_true",
+                        help="build with little information")
 
     return Parser.parse_args()
 
 
-## Entrance method
+# Entrance method
 #
 # @retval 0     Tool was successful
 # @retval 1     Tool failed
 #
 def Main():
     EdkLogger.Initialize()
-    Option, Input = GetOptions()
+    Arguments = GetOptions()
 
     # Set log level
-    if Option.quiet:
+    if Arguments.quiet:
         EdkLogger.SetLevel(EdkLogger.QUIET)
-    elif Option.verbose:
+    elif Arguments.verbose:
         EdkLogger.SetLevel(EdkLogger.VERBOSE)
-    elif Option.debug is not None:
-        EdkLogger.SetLevel(Option.debug + 1)
+    elif Arguments.debug is not None:
+        EdkLogger.SetLevel(Arguments.debug + 1)
     else:
         EdkLogger.SetLevel(EdkLogger.INFO)
 
     try:
-        if Option.ModuleType is None or Option.ModuleType not in gType2Phase:
-            EdkLogger.error("GenDepex", OPTION_MISSING, "Module type is not specified or supported")
+        if Arguments.ModuleType not in gType2Phase:
+            EdkLogger.error("GenDepex", OPTION_MISSING, "Module type is not supported")
 
         DxsFile = ''
-        if len(Input) > 0 and Option.Expression == "":
+        Input = Arguments.DependencyExpressionFile
+        if Input is not None and Arguments.Expression == "":
             DxsFile = Input[0]
             DxsString = open(DxsFile, 'r').read().replace("\n", " ").replace("\r", " ")
             DxsString = gStartClosePattern.sub("\\1", DxsString)
-        elif Option.Expression != "":
-            if Option.Expression[0] == '"':
-                DxsString = Option.Expression[1:-1]
+        elif Arguments.Expression != "":
+            if Arguments.Expression[0] == '"':
+                DxsString = Arguments.Expression[1:-1]
             else:
-                DxsString = Option.Expression
+                DxsString = Arguments.Expression
         else:
             EdkLogger.error("GenDepex", OPTION_MISSING, "No expression string or file given")
 
-        Dpx = DependencyExpression(DxsString, Option.ModuleType, Option.Optimize)
-        if Option.OutputFile is not None:
-            FileChangeFlag = Dpx.Generate(Option.OutputFile)
+        Dpx = DependencyExpression(DxsString, Arguments.ModuleType, Arguments.Optimize)
+        if Arguments.OutputFile is not None:
+            FileChangeFlag = Dpx.Generate(Arguments.OutputFile)
             if not FileChangeFlag and DxsFile:
                 #
                 # Touch the output file if its time stamp is older than the original
                 # DXS file to avoid re-invoke this tool for the dependency check in build rule.
                 #
-                if os.stat(DxsFile)[8] > os.stat(Option.OutputFile)[8]:
-                    os.utime(Option.OutputFile, None)
+                if os.stat(DxsFile)[8] > os.stat(Arguments.OutputFile)[8]:
+                    os.utime(Arguments.OutputFile, None)
         else:
             Dpx.Generate()
     except BaseException as X:
         EdkLogger.quiet("")
-        if Option is not None and Option.debug is not None:
+        if Arguments is not None and Arguments.debug is not None:
             EdkLogger.quiet(traceback.format_exc())
         else:
             EdkLogger.quiet(str(X))
@@ -459,6 +470,6 @@ def Main():
 
     return 0
 
+
 if __name__ == '__main__':
     sys.exit(Main())
-

--- a/edk2basetools/AutoGen/PlatformAutoGen.py
+++ b/edk2basetools/AutoGen/PlatformAutoGen.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # Create makefile for MS nmake and GNU make
 #
 # Copyright (c) 2019 - 2021, Intel Corporation. All rights reserved.<BR>
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-## Import Modules
+# Import Modules
 #
 from __future__ import print_function
 from __future__ import absolute_import
@@ -14,7 +14,7 @@ import os.path as path
 import copy
 from collections import defaultdict
 
-from .BuildEngine import BuildRule,gDefaultBuildRuleFile,AutoGenReqBuildRuleVerNum
+from .BuildEngine import BuildRule, gDefaultBuildRuleFile, AutoGenReqBuildRuleVerNum
 from .GenVar import VariableMgr, var_info
 from . import GenMake
 from edk2basetools.AutoGen.DataPipe import MemoryDataPipe
@@ -25,17 +25,19 @@ from edk2basetools.Workspace.WorkspaceCommon import GetModuleLibInstances
 from edk2basetools.CommonDataClass.CommonClass import SkuInfoClass
 from edk2basetools.Common.caching import cached_class_function
 from edk2basetools.Common.Expression import ValueExpressionEx
-from edk2basetools.Common.StringUtils import StringToArray,NormPath
+from edk2basetools.Common.StringUtils import StringToArray, NormPath
 from edk2basetools.Common.BuildToolError import *
 from edk2basetools.Common.DataType import *
 from edk2basetools.Common.Misc import *
 import edk2basetools.Common.VpdInfoFile as VpdInfoFile
 
-## Split command line option string to list
+# Split command line option string to list
 #
 # subprocess.Popen needs the args to be a sequence. Otherwise there's problem
 # in non-windows platform to launch command
 #
+
+
 def _SplitOption(OptionString):
     OptionList = []
     LastChar = " "
@@ -60,11 +62,13 @@ def _SplitOption(OptionString):
     OptionList.append(OptionString[OptionStart:])
     return OptionList
 
-## AutoGen class for platform
+# AutoGen class for platform
 #
 #  PlatformAutoGen class will process the original information in platform
 #  file in order to generate makefile for platform.
 #
+
+
 class PlatformAutoGen(AutoGen):
     # call super().__init__ then call the worker function with different parameter count
     def __init__(self, Workspace, MetaFile, Target, Toolchain, Arch, *args, **kwargs):
@@ -79,9 +83,7 @@ class PlatformAutoGen(AutoGen):
     _NonDynaPcdList_ = []
     _PlatformPcds = {}
 
-
-
-    ## Initialize PlatformAutoGen
+    # Initialize PlatformAutoGen
     #
     #
     #   @param      Workspace       WorkspaceAutoGen object
@@ -90,6 +92,7 @@ class PlatformAutoGen(AutoGen):
     #   @param      Toolchain       Name of tool chain
     #   @param      Arch            arch of the platform supports
     #
+
     def _InitWorker(self, Workspace, PlatformFile, Target, Toolchain, Arch):
         EdkLogger.debug(EdkLogger.DEBUG_9, "AutoGen platform [%s] [%s]" % (PlatformFile, Arch))
         GlobalData.gProcessingFile = "%s [%s, %s, %s]" % (PlatformFile, Arch, Toolchain, Target)
@@ -112,7 +115,8 @@ class PlatformAutoGen(AutoGen):
         self.MakeFileName = ""
 
         self._DynamicPcdList = None    # [(TokenCName1, TokenSpaceGuidCName1), (TokenCName2, TokenSpaceGuidCName2), ...]
-        self._NonDynamicPcdList = None # [(TokenCName1, TokenSpaceGuidCName1), (TokenCName2, TokenSpaceGuidCName2), ...]
+        # [(TokenCName1, TokenSpaceGuidCName1), (TokenCName2, TokenSpaceGuidCName2), ...]
+        self._NonDynamicPcdList = None
 
         self._AsBuildInfList = []
         self._AsBuildModuleList = []
@@ -135,27 +139,31 @@ class PlatformAutoGen(AutoGen):
         self.DataPipe.FillData(self)
 
         return True
+
     def FillData_LibConstPcd(self):
         libConstPcd = {}
         for LibAuto in self.LibraryAutoGenList:
             if LibAuto.ConstPcd:
-                libConstPcd[(LibAuto.MetaFile.File,LibAuto.MetaFile.Root,LibAuto.Arch,LibAuto.MetaFile.Path)] = LibAuto.ConstPcd
-        self.DataPipe.DataContainer = {"LibConstPcd":libConstPcd}
-    ## hash() operator of PlatformAutoGen
+                libConstPcd[(LibAuto.MetaFile.File, LibAuto.MetaFile.Root,
+                             LibAuto.Arch, LibAuto.MetaFile.Path)] = LibAuto.ConstPcd
+        self.DataPipe.DataContainer = {"LibConstPcd": libConstPcd}
+    # hash() operator of PlatformAutoGen
     #
     #  The platform file path and arch string will be used to represent
     #  hash value of this object
     #
     #   @retval   int Hash value of the platform file path and arch
     #
+
     @cached_class_function
     def __hash__(self):
-        return hash((self.MetaFile, self.Arch,self.ToolChain,self.BuildTarget))
+        return hash((self.MetaFile, self.Arch, self.ToolChain, self.BuildTarget))
+
     @cached_class_function
     def __repr__(self):
         return "%s [%s]" % (self.MetaFile, self.Arch)
 
-    ## Create autogen code for platform and modules
+    # Create autogen code for platform and modules
     #
     #  Since there's no autogen code for platform, this method will do nothing
     #  if CreateModuleCodeFile is set to False.
@@ -172,17 +180,17 @@ class PlatformAutoGen(AutoGen):
         for Ma in self.ModuleAutoGenList:
             Ma.CreateCodeFile(CreateModuleCodeFile)
 
-    ## Generate Fds Command
+    # Generate Fds Command
     @cached_property
     def GenFdsCommand(self):
         return self.Workspace.GenFdsCommand
 
-    ## Create makefile for the platform and modules in it
+    # Create makefile for the platform and modules in it
     #
     #   @param      CreateModuleMakeFile    Flag indicating if the makefile for
     #                                       modules will be created as well
     #
-    def CreateMakeFile(self, CreateModuleMakeFile=False, FfsCommand = {}):
+    def CreateMakeFile(self, CreateModuleMakeFile=False, FfsCommand={}):
         if CreateModuleMakeFile:
             for Ma in self._MaList:
                 key = (Ma.MetaFile.File, self.Arch)
@@ -206,8 +214,9 @@ class PlatformAutoGen(AutoGen):
     @property
     def AllPcdList(self):
         return self.DynamicPcdList + self.NonDynamicPcdList
-    ## Deal with Shared FixedAtBuild Pcds
+    # Deal with Shared FixedAtBuild Pcds
     #
+
     def CollectFixedAtBuildPcds(self):
         for LibAuto in self.LibraryAutoGenList:
             FixedAtBuildPcds = {}
@@ -266,14 +275,16 @@ class PlatformAutoGen(AutoGen):
                     VariableGuidStructure = Sku.VariableGuidValue
                     VariableGuid = GuidStructureStringToGuidString(VariableGuidStructure)
                     for StorageName in Sku.DefaultStoreDict:
-                        VariableInfo.append_variable(var_info(Index, pcdname, StorageName, SkuName, StringToArray(Sku.VariableName), VariableGuid, Sku.VariableOffset, Sku.VariableAttribute, Sku.HiiDefaultValue, Sku.DefaultStoreDict[StorageName] if Pcd.DatumType in TAB_PCD_NUMERIC_TYPES else StringToArray(Sku.DefaultStoreDict[StorageName]), Pcd.DatumType, Pcd.CustomAttribute['DscPosition'], Pcd.CustomAttribute.get('IsStru',False)))
+                        VariableInfo.append_variable(var_info(Index, pcdname, StorageName, SkuName, StringToArray(Sku.VariableName), VariableGuid, Sku.VariableOffset, Sku.VariableAttribute, Sku.HiiDefaultValue, Sku.DefaultStoreDict[
+                                                     StorageName] if Pcd.DatumType in TAB_PCD_NUMERIC_TYPES else StringToArray(Sku.DefaultStoreDict[StorageName]), Pcd.DatumType, Pcd.CustomAttribute['DscPosition'], Pcd.CustomAttribute.get('IsStru', False)))
             Index += 1
         return VariableInfo
 
     def UpdateNVStoreMaxSize(self, OrgVpdFile):
         if self.VariableInfo:
             VpdMapFilePath = os.path.join(self.BuildDir, TAB_FV_DIRECTORY, "%s.map" % self.Platform.VpdToolGuid)
-            PcdNvStoreDfBuffer = [item for item in self._DynamicPcdList if item.TokenCName == "PcdNvStoreDefaultValueBuffer" and item.TokenSpaceGuidCName == "gEfiMdeModulePkgTokenSpaceGuid"]
+            PcdNvStoreDfBuffer = [item for item in self._DynamicPcdList if item.TokenCName ==
+                                  "PcdNvStoreDefaultValueBuffer" and item.TokenSpaceGuidCName == "gEfiMdeModulePkgTokenSpaceGuid"]
 
             if PcdNvStoreDfBuffer:
                 try:
@@ -281,11 +292,13 @@ class PlatformAutoGen(AutoGen):
                     PcdItems = OrgVpdFile.GetOffset(PcdNvStoreDfBuffer[0])
                     NvStoreOffset = list(PcdItems.values())[0].strip() if PcdItems else '0'
                 except:
-                    EdkLogger.error("build", FILE_READ_FAILURE, "Can not find VPD map file %s to fix up VPD offset." % VpdMapFilePath)
+                    EdkLogger.error("build", FILE_READ_FAILURE,
+                                    "Can not find VPD map file %s to fix up VPD offset." % VpdMapFilePath)
 
                 NvStoreOffset = int(NvStoreOffset, 16) if NvStoreOffset.upper().startswith("0X") else int(NvStoreOffset)
                 default_skuobj = PcdNvStoreDfBuffer[0].SkuInfoList.get(TAB_DEFAULT)
-                maxsize = self.VariableInfo.VpdRegionSize  - NvStoreOffset if self.VariableInfo.VpdRegionSize else len(default_skuobj.DefaultValue.split(","))
+                maxsize = self.VariableInfo.VpdRegionSize - \
+                    NvStoreOffset if self.VariableInfo.VpdRegionSize else len(default_skuobj.DefaultValue.split(","))
                 var_data = self.VariableInfo.PatchNVStoreDefaultMaxSize(maxsize)
 
                 if var_data and default_skuobj:
@@ -297,7 +310,7 @@ class PlatformAutoGen(AutoGen):
 
         return OrgVpdFile
 
-    ## Collect dynamic PCDs
+    # Collect dynamic PCDs
     #
     #  Gather dynamic PCDs list from each module and their settings from platform
     #  This interface should be invoked explicitly when platform action is created.
@@ -315,7 +328,7 @@ class PlatformAutoGen(AutoGen):
             InfName = mws.join(self.WorkspaceDir, InfName)
             FdfModuleList.append(os.path.normpath(InfName))
         for M in self._MbList:
-#            F is the Module for which M is the module autogen
+            #            F is the Module for which M is the module autogen
             ModPcdList = self.ApplyPcdSetting(M, M.ModulePcdList)
             LibPcdList = []
             for lib in M.LibraryPcdList:
@@ -324,14 +337,16 @@ class PlatformAutoGen(AutoGen):
 
                 # make sure that the "VOID*" kind of datum has MaxDatumSize set
                 if PcdFromModule.DatumType == TAB_VOID and not PcdFromModule.MaxDatumSize:
-                    NoDatumTypePcdList.add("%s.%s [%s]" % (PcdFromModule.TokenSpaceGuidCName, PcdFromModule.TokenCName, M.MetaFile))
+                    NoDatumTypePcdList.add("%s.%s [%s]" % (
+                        PcdFromModule.TokenSpaceGuidCName, PcdFromModule.TokenCName, M.MetaFile))
 
                 # Check the PCD from Binary INF or Source INF
                 if M.IsBinaryModule == True:
                     PcdFromModule.IsFromBinaryInf = True
 
                 # Check the PCD from DSC or not
-                PcdFromModule.IsFromDsc = (PcdFromModule.TokenCName, PcdFromModule.TokenSpaceGuidCName) in self.Platform.Pcds
+                PcdFromModule.IsFromDsc = (PcdFromModule.TokenCName,
+                                           PcdFromModule.TokenSpaceGuidCName) in self.Platform.Pcds
 
                 if PcdFromModule.Type in PCD_DYNAMIC_TYPE_SET or PcdFromModule.Type in PCD_DYNAMIC_EX_TYPE_SET:
                     if M.MetaFile.Path not in FdfModuleList:
@@ -344,7 +359,7 @@ class PlatformAutoGen(AutoGen):
                         # PCD will not be added into the Database unless it is used by other
                         # modules that are included in the FDF file.
                         if PcdFromModule.Type in PCD_DYNAMIC_TYPE_SET and \
-                            PcdFromModule.IsFromBinaryInf == False:
+                                PcdFromModule.IsFromBinaryInf == False:
                             # Print warning message to let the developer make a determine.
                             continue
                         # If one of the Source built modules listed in the DSC is not listed in
@@ -373,10 +388,10 @@ class PlatformAutoGen(AutoGen):
                 elif PcdFromModule in self._NonDynaPcdList_ and PcdFromModule.IsFromBinaryInf == True:
                     Index = self._NonDynaPcdList_.index(PcdFromModule)
                     if self._NonDynaPcdList_[Index].IsFromBinaryInf == False:
-                        #The PCD from Binary INF will override the same one from source INF
-                        self._NonDynaPcdList_.remove (self._NonDynaPcdList_[Index])
+                        # The PCD from Binary INF will override the same one from source INF
+                        self._NonDynaPcdList_.remove(self._NonDynaPcdList_[Index])
                         PcdFromModule.Pending = False
-                        self._NonDynaPcdList_.append (PcdFromModule)
+                        self._NonDynaPcdList_.append(PcdFromModule)
         DscModuleSet = {os.path.normpath(ModuleInf.Path) for ModuleInf in self.Platform.Modules}
         # add the PCD from modules that listed in FDF but not in DSC to Database
         for InfName in FdfModuleList:
@@ -401,7 +416,8 @@ class PlatformAutoGen(AutoGen):
                                         % (PcdFromModule.Type, PcdFromModule.TokenCName, InfName))
                     # make sure that the "VOID*" kind of datum has MaxDatumSize set
                     if PcdFromModule.DatumType == TAB_VOID and not PcdFromModule.MaxDatumSize:
-                        NoDatumTypePcdList.add("%s.%s [%s]" % (PcdFromModule.TokenSpaceGuidCName, PcdFromModule.TokenCName, InfName))
+                        NoDatumTypePcdList.add("%s.%s [%s]" % (
+                            PcdFromModule.TokenSpaceGuidCName, PcdFromModule.TokenCName, InfName))
                     if M.ModuleType in SUP_MODULE_SET_PEI:
                         PcdFromModule.Phase = "PEI"
                     if PcdFromModule not in self._DynaPcdList_ and PcdFromModule.Type in PCD_DYNAMIC_EX_TYPE_SET:
@@ -429,11 +445,11 @@ class PlatformAutoGen(AutoGen):
                 continue
             Index = self._DynaPcdList_.index(PcdFromModule)
             if PcdFromModule.IsFromDsc == False and \
-                PcdFromModule.Type in TAB_PCDS_PATCHABLE_IN_MODULE and \
-                PcdFromModule.IsFromBinaryInf == True and \
-                self._DynaPcdList_[Index].IsFromBinaryInf == False:
+                    PcdFromModule.Type in TAB_PCDS_PATCHABLE_IN_MODULE and \
+                    PcdFromModule.IsFromBinaryInf == True and \
+                    self._DynaPcdList_[Index].IsFromBinaryInf == False:
                 Index = self._DynaPcdList_.index(PcdFromModule)
-                self._DynaPcdList_.remove (self._DynaPcdList_[Index])
+                self._DynaPcdList_.remove(self._DynaPcdList_[Index])
 
         # print out error information and break the build, if error found
         if len(NoDatumTypePcdList) > 0:
@@ -455,10 +471,10 @@ class PlatformAutoGen(AutoGen):
         # The reason of sorting is make sure the unicode string is in double-byte alignment in string table.
         #
         UnicodePcdArray = set()
-        HiiPcdArray     = set()
-        OtherPcdArray   = set()
-        VpdPcdDict      = {}
-        VpdFile               = VpdInfoFile.VpdInfoFile()
+        HiiPcdArray = set()
+        OtherPcdArray = set()
+        VpdPcdDict = {}
+        VpdFile = VpdInfoFile.VpdInfoFile()
         NeedProcessVpdMapFile = False
 
         for pcd in self.Platform.Pcds:
@@ -483,27 +499,29 @@ class PlatformAutoGen(AutoGen):
                 if Pcd.Type in [TAB_PCDS_DYNAMIC_VPD, TAB_PCDS_DYNAMIC_EX_VPD]:
                     VpdPcdDict[(Pcd.TokenCName, Pcd.TokenSpaceGuidCName)] = Pcd
 
-            #Collect DynamicHii PCD values and assign it to DynamicExVpd PCD gEfiMdeModulePkgTokenSpaceGuid.PcdNvStoreDefaultValueBuffer
+            # Collect DynamicHii PCD values and assign it to DynamicExVpd PCD gEfiMdeModulePkgTokenSpaceGuid.PcdNvStoreDefaultValueBuffer
             PcdNvStoreDfBuffer = VpdPcdDict.get(("PcdNvStoreDefaultValueBuffer", "gEfiMdeModulePkgTokenSpaceGuid"))
             if PcdNvStoreDfBuffer:
                 self.VariableInfo = self.CollectVariables(self._DynamicPcdList)
                 vardump = self.VariableInfo.dump()
                 if vardump:
                     #
-                    #According to PCD_DATABASE_INIT in edk2\MdeModulePkg\Include\Guid\PcdDataBaseSignatureGuid.h,
-                    #the max size for string PCD should not exceed USHRT_MAX 65535(0xffff).
-                    #typedef UINT16 SIZE_INFO;
-                    #//SIZE_INFO  SizeTable[];
+                    # According to PCD_DATABASE_INIT in edk2\MdeModulePkg\Include\Guid\PcdDataBaseSignatureGuid.h,
+                    # the max size for string PCD should not exceed USHRT_MAX 65535(0xffff).
+                    # typedef UINT16 SIZE_INFO;
+                    # //SIZE_INFO  SizeTable[];
                     if len(vardump.split(",")) > 0xffff:
-                        EdkLogger.error("build", RESOURCE_OVERFLOW, 'The current length of PCD %s value is %d, it exceeds to the max size of String PCD.' %(".".join([PcdNvStoreDfBuffer.TokenSpaceGuidCName,PcdNvStoreDfBuffer.TokenCName]) ,len(vardump.split(","))))
+                        EdkLogger.error("build", RESOURCE_OVERFLOW, 'The current length of PCD %s value is %d, it exceeds to the max size of String PCD.' % (
+                            ".".join([PcdNvStoreDfBuffer.TokenSpaceGuidCName, PcdNvStoreDfBuffer.TokenCName]), len(vardump.split(","))))
                     PcdNvStoreDfBuffer.DefaultValue = vardump
                     for skuname in PcdNvStoreDfBuffer.SkuInfoList:
                         PcdNvStoreDfBuffer.SkuInfoList[skuname].DefaultValue = vardump
                         PcdNvStoreDfBuffer.MaxDatumSize = str(len(vardump.split(",")))
             else:
-                #If the end user define [DefaultStores] and [XXX.Menufacturing] in DSC, but forget to configure PcdNvStoreDefaultValueBuffer to PcdsDynamicVpd
+                # If the end user define [DefaultStores] and [XXX.Menufacturing] in DSC, but forget to configure PcdNvStoreDefaultValueBuffer to PcdsDynamicVpd
                 if [Pcd for Pcd in self._DynamicPcdList if Pcd.UserDefinedDefaultStoresFlag]:
-                    EdkLogger.warn("build", "PcdNvStoreDefaultValueBuffer should be defined as PcdsDynamicExVpd in dsc file since the DefaultStores is enabled for this platform.\n%s" %self.Platform.MetaFile.Path)
+                    EdkLogger.warn(
+                        "build", "PcdNvStoreDefaultValueBuffer should be defined as PcdsDynamicExVpd in dsc file since the DefaultStores is enabled for this platform.\n%s" % self.Platform.MetaFile.Path)
             PlatformPcds = sorted(self._PlatformPcds.keys())
             #
             # Add VPD type PCD into VpdFile and determine whether the VPD PCD need to be fixed up.
@@ -527,7 +545,7 @@ class PlatformAutoGen(AutoGen):
                         Sku.VpdOffset = Sku.VpdOffset.strip()
                         PcdValue = Sku.DefaultValue
                         if PcdValue == "":
-                            PcdValue  = Pcd.DefaultValue
+                            PcdValue = Pcd.DefaultValue
                         if Sku.VpdOffset != TAB_STAR:
                             if PcdValue.startswith("{"):
                                 Alignment = 8
@@ -541,12 +559,15 @@ class PlatformAutoGen(AutoGen):
                                 try:
                                     VpdOffset = int(Sku.VpdOffset, 16)
                                 except:
-                                    EdkLogger.error("build", FORMAT_INVALID, "Invalid offset value %s for PCD %s.%s." % (Sku.VpdOffset, Pcd.TokenSpaceGuidCName, Pcd.TokenCName))
+                                    EdkLogger.error("build", FORMAT_INVALID, "Invalid offset value %s for PCD %s.%s." % (
+                                        Sku.VpdOffset, Pcd.TokenSpaceGuidCName, Pcd.TokenCName))
                             if VpdOffset % Alignment != 0:
                                 if PcdValue.startswith("{"):
-                                    EdkLogger.warn("build", "The offset value of PCD %s.%s is not 8-byte aligned!" %(Pcd.TokenSpaceGuidCName, Pcd.TokenCName), File=self.MetaFile)
+                                    EdkLogger.warn("build", "The offset value of PCD %s.%s is not 8-byte aligned!" %
+                                                   (Pcd.TokenSpaceGuidCName, Pcd.TokenCName), File=self.MetaFile)
                                 else:
-                                    EdkLogger.error("build", FORMAT_INVALID, 'The offset value of PCD %s.%s should be %s-byte aligned.' % (Pcd.TokenSpaceGuidCName, Pcd.TokenCName, Alignment))
+                                    EdkLogger.error("build", FORMAT_INVALID, 'The offset value of PCD %s.%s should be %s-byte aligned.' %
+                                                    (Pcd.TokenSpaceGuidCName, Pcd.TokenCName, Alignment))
                         if PcdValue not in SkuValueMap:
                             SkuValueMap[PcdValue] = []
                             VpdFile.Add(Pcd, SkuName, Sku.VpdOffset)
@@ -555,7 +576,7 @@ class PlatformAutoGen(AutoGen):
                         if not NeedProcessVpdMapFile and Sku.VpdOffset == TAB_STAR:
                             NeedProcessVpdMapFile = True
                             if self.Platform.VpdToolGuid is None or self.Platform.VpdToolGuid == '':
-                                EdkLogger.error("Build", FILE_NOT_FOUND, \
+                                EdkLogger.error("Build", FILE_NOT_FOUND,
                                                 "Fail to find third-party BPDG tool to process VPD PCDs. BPDG Guid tool need to be defined in tools_def.txt and VPD_TOOL_GUID need to be provided in DSC file.")
 
                     VpdSkuMap[PcdKey] = SkuValueMap
@@ -572,10 +593,10 @@ class PlatformAutoGen(AutoGen):
                             # This PCD has been referenced by module
                             if (VpdPcd.TokenSpaceGuidCName == DscPcdEntry.TokenSpaceGuidCName) and \
                                (VpdPcd.TokenCName == DscPcdEntry.TokenCName):
-                                    FoundFlag = True
+                                FoundFlag = True
 
                         # Not found, it should be signature
-                        if not FoundFlag :
+                        if not FoundFlag:
                             # just pick the a value to determine whether is unicode string type
                             SkuValueMap = {}
                             SkuObjList = list(DscPcdEntry.SkuInfoList.items())
@@ -594,24 +615,25 @@ class PlatformAutoGen(AutoGen):
                                            (DecPcdEntry.TokenCName == DscPcdEntry.TokenCName):
                                             # Print warning message to let the developer make a determine.
                                             EdkLogger.warn("build", "Unreferenced vpd pcd used!",
-                                                            File=self.MetaFile, \
-                                                            ExtraData = "PCD: %s.%s used in the DSC file %s is unreferenced." \
-                                                            %(DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName, self.Platform.MetaFile.Path))
+                                                           File=self.MetaFile,
+                                                           ExtraData="PCD: %s.%s used in the DSC file %s is unreferenced."
+                                                           % (DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName, self.Platform.MetaFile.Path))
 
-                                            DscPcdEntry.DatumType    = DecPcdEntry.DatumType
+                                            DscPcdEntry.DatumType = DecPcdEntry.DatumType
                                             DscPcdEntry.DefaultValue = DecPcdEntry.DefaultValue
                                             DscPcdEntry.TokenValue = DecPcdEntry.TokenValue
                                             DscPcdEntry.TokenSpaceGuidValue = eachDec.Guids[DecPcdEntry.TokenSpaceGuidCName]
                                             # Only fix the value while no value provided in DSC file.
                                             if not Sku.DefaultValue:
-                                                DscPcdEntry.SkuInfoList[list(DscPcdEntry.SkuInfoList.keys())[0]].DefaultValue = DecPcdEntry.DefaultValue
+                                                DscPcdEntry.SkuInfoList[list(DscPcdEntry.SkuInfoList.keys())[
+                                                    0]].DefaultValue = DecPcdEntry.DefaultValue
 
                                 if DscPcdEntry not in self._DynamicPcdList:
                                     self._DynamicPcdList.append(DscPcdEntry)
                                 Sku.VpdOffset = Sku.VpdOffset.strip()
                                 PcdValue = Sku.DefaultValue
                                 if PcdValue == "":
-                                    PcdValue  = DscPcdEntry.DefaultValue
+                                    PcdValue = DscPcdEntry.DefaultValue
                                 if Sku.VpdOffset != TAB_STAR:
                                     if PcdValue.startswith("{"):
                                         Alignment = 8
@@ -625,12 +647,15 @@ class PlatformAutoGen(AutoGen):
                                         try:
                                             VpdOffset = int(Sku.VpdOffset, 16)
                                         except:
-                                            EdkLogger.error("build", FORMAT_INVALID, "Invalid offset value %s for PCD %s.%s." % (Sku.VpdOffset, DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName))
+                                            EdkLogger.error("build", FORMAT_INVALID, "Invalid offset value %s for PCD %s.%s." % (
+                                                Sku.VpdOffset, DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName))
                                     if VpdOffset % Alignment != 0:
                                         if PcdValue.startswith("{"):
-                                            EdkLogger.warn("build", "The offset value of PCD %s.%s is not 8-byte aligned!" %(DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName), File=self.MetaFile)
+                                            EdkLogger.warn("build", "The offset value of PCD %s.%s is not 8-byte aligned!" %
+                                                           (DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName), File=self.MetaFile)
                                         else:
-                                            EdkLogger.error("build", FORMAT_INVALID, 'The offset value of PCD %s.%s should be %s-byte aligned.' % (DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName, Alignment))
+                                            EdkLogger.error("build", FORMAT_INVALID, 'The offset value of PCD %s.%s should be %s-byte aligned.' % (
+                                                DscPcdEntry.TokenSpaceGuidCName, DscPcdEntry.TokenCName, Alignment))
                                 if PcdValue not in SkuValueMap:
                                     SkuValueMap[PcdValue] = []
                                     VpdFile.Add(DscPcdEntry, SkuName, Sku.VpdOffset)
@@ -656,12 +681,14 @@ class PlatformAutoGen(AutoGen):
                 self.FixVpdOffset(VpdFile)
 
                 self.FixVpdOffset(self.UpdateNVStoreMaxSize(VpdFile))
-                PcdNvStoreDfBuffer = [item for item in self._DynamicPcdList if item.TokenCName == "PcdNvStoreDefaultValueBuffer" and item.TokenSpaceGuidCName == "gEfiMdeModulePkgTokenSpaceGuid"]
+                PcdNvStoreDfBuffer = [item for item in self._DynamicPcdList if item.TokenCName ==
+                                      "PcdNvStoreDefaultValueBuffer" and item.TokenSpaceGuidCName == "gEfiMdeModulePkgTokenSpaceGuid"]
                 if PcdNvStoreDfBuffer:
-                    PcdName,PcdGuid = PcdNvStoreDfBuffer[0].TokenCName, PcdNvStoreDfBuffer[0].TokenSpaceGuidCName
-                    if (PcdName,PcdGuid) in VpdSkuMap:
+                    PcdName, PcdGuid = PcdNvStoreDfBuffer[0].TokenCName, PcdNvStoreDfBuffer[0].TokenSpaceGuidCName
+                    if (PcdName, PcdGuid) in VpdSkuMap:
                         DefaultSku = PcdNvStoreDfBuffer[0].SkuInfoList.get(TAB_DEFAULT)
-                        VpdSkuMap[(PcdName,PcdGuid)] = {DefaultSku.DefaultValue:[SkuObj for SkuObj in PcdNvStoreDfBuffer[0].SkuInfoList.values() ]}
+                        VpdSkuMap[(PcdName, PcdGuid)] = {DefaultSku.DefaultValue: [
+                            SkuObj for SkuObj in PcdNvStoreDfBuffer[0].SkuInfoList.values()]}
 
                 # Process VPD map file generated by third party BPDG tool
                 if NeedProcessVpdMapFile:
@@ -673,7 +700,7 @@ class PlatformAutoGen(AutoGen):
                         for pcd in VpdSkuMap:
                             vpdinfo = VpdFile.GetVpdInfo(pcd)
                             if vpdinfo is None:
-                            # just pick the a value to determine whether is unicode string type
+                                # just pick the a value to determine whether is unicode string type
                                 continue
                             for pcdvalue in VpdSkuMap[pcd]:
                                 for sku in VpdSkuMap[pcd][pcdvalue]:
@@ -681,7 +708,8 @@ class PlatformAutoGen(AutoGen):
                                         if item[2] == pcdvalue:
                                             sku.VpdOffset = item[1]
                     except:
-                        EdkLogger.error("build", FILE_READ_FAILURE, "Can not find VPD map file %s to fix up VPD offset." % VpdMapFilePath)
+                        EdkLogger.error("build", FILE_READ_FAILURE,
+                                        "Can not find VPD map file %s to fix up VPD offset." % VpdMapFilePath)
 
             # Delete the DynamicPcdList At the last time enter into this function
             for Pcd in self._DynamicPcdList:
@@ -716,7 +744,7 @@ class PlatformAutoGen(AutoGen):
                     pcd.SkuInfoList[SkuName].SkuId = SkuId
                     pcd.SkuInfoList[SkuName].SkuIdName = SkuName
 
-    def FixVpdOffset(self, VpdFile ):
+    def FixVpdOffset(self, VpdFile):
         FvPath = os.path.join(self.BuildDir, TAB_FV_DIRECTORY)
         if not os.path.exists(FvPath):
             try:
@@ -732,66 +760,68 @@ class PlatformAutoGen(AutoGen):
             for ToolDef in self.ToolDefinition.values():
                 if TAB_GUID in ToolDef and ToolDef[TAB_GUID] == self.Platform.VpdToolGuid:
                     if "PATH" not in ToolDef:
-                        EdkLogger.error("build", ATTRIBUTE_NOT_AVAILABLE, "PATH attribute was not provided for BPDG guid tool %s in tools_def.txt" % self.Platform.VpdToolGuid)
+                        EdkLogger.error("build", ATTRIBUTE_NOT_AVAILABLE,
+                                        "PATH attribute was not provided for BPDG guid tool %s in tools_def.txt" % self.Platform.VpdToolGuid)
                     BPDGToolName = ToolDef["PATH"]
                     break
             # Call third party GUID BPDG tool.
             if BPDGToolName is not None:
                 VpdInfoFile.CallExtenalBPDGTool(BPDGToolName, VpdFilePath)
             else:
-                EdkLogger.error("Build", FILE_NOT_FOUND, "Fail to find third-party BPDG tool to process VPD PCDs. BPDG Guid tool need to be defined in tools_def.txt and VPD_TOOL_GUID need to be provided in DSC file.")
+                EdkLogger.error(
+                    "Build", FILE_NOT_FOUND, "Fail to find third-party BPDG tool to process VPD PCDs. BPDG Guid tool need to be defined in tools_def.txt and VPD_TOOL_GUID need to be provided in DSC file.")
 
-    ## Return the platform build data object
+    # Return the platform build data object
     @cached_property
     def Platform(self):
         return self.BuildDatabase[self.MetaFile, self.Arch, self.BuildTarget, self.ToolChain]
 
-    ## Return platform name
+    # Return platform name
     @cached_property
     def Name(self):
         return self.Platform.PlatformName
 
-    ## Return the meta file GUID
+    # Return the meta file GUID
     @cached_property
     def Guid(self):
         return self.Platform.Guid
 
-    ## Return the platform version
+    # Return the platform version
     @cached_property
     def Version(self):
         return self.Platform.Version
 
-    ## Return the FDF file name
+    # Return the FDF file name
     @cached_property
     def FdfFile(self):
         if self.Workspace.FdfFile:
-            RetVal= mws.join(self.WorkspaceDir, self.Workspace.FdfFile)
+            RetVal = mws.join(self.WorkspaceDir, self.Workspace.FdfFile)
         else:
             RetVal = ''
         return RetVal
 
-    ## Return the build output directory platform specifies
+    # Return the build output directory platform specifies
     @cached_property
     def OutputDir(self):
         return self.Platform.OutputDirectory
 
-    ## Return the directory to store all intermediate and final files built
+    # Return the directory to store all intermediate and final files built
     @cached_property
     def BuildDir(self):
         if os.path.isabs(self.OutputDir):
             GlobalData.gBuildDirectory = RetVal = path.join(
-                                        path.abspath(self.OutputDir),
-                                        self.BuildTarget + "_" + self.ToolChain,
-                                        )
+                path.abspath(self.OutputDir),
+                self.BuildTarget + "_" + self.ToolChain,
+            )
         else:
             GlobalData.gBuildDirectory = RetVal = path.join(
-                                        self.WorkspaceDir,
-                                        self.OutputDir,
-                                        self.BuildTarget + "_" + self.ToolChain,
-                                        )
+                self.WorkspaceDir,
+                self.OutputDir,
+                self.BuildTarget + "_" + self.ToolChain,
+            )
         return RetVal
 
-    ## Return directory of platform makefile
+    # Return directory of platform makefile
     #
     #   @retval     string  Makefile directory
     #
@@ -799,7 +829,7 @@ class PlatformAutoGen(AutoGen):
     def MakeFileDir(self):
         return path.join(self.BuildDir, self.Arch)
 
-    ## Return build command string
+    # Return build command string
     #
     #   @retval     string  Build command string
     #
@@ -827,7 +857,7 @@ class PlatformAutoGen(AutoGen):
                 RetVal = RetVal + _SplitOption(Flags.strip())
         return RetVal
 
-    ## Compute a tool defintion key priority value in range 0..15
+    # Compute a tool defintion key priority value in range 0..15
     #
     #  TARGET_TOOLCHAIN_ARCH_COMMANDTYPE_ATTRIBUTE  15
     #  ******_TOOLCHAIN_ARCH_COMMANDTYPE_ATTRIBUTE  14
@@ -846,15 +876,15 @@ class PlatformAutoGen(AutoGen):
     #  TARGET_*********_****_***********_ATTRIBUTE   1
     #  ******_*********_****_***********_ATTRIBUTE   0
     #
-    def ToolDefinitionPriority (self,Key):
+    def ToolDefinitionPriority(self, Key):
         KeyList = Key.split('_')
         Priority = 0
-        for Index in range (0, min(4, len(KeyList))):
+        for Index in range(0, min(4, len(KeyList))):
             if KeyList[Index] != '*':
                 Priority += (1 << Index)
         return Priority
 
-    ## Get tool chain definition
+    # Get tool chain definition
     #
     #  Get each tool definition for given tool chain from tools_def.txt and platform
     #
@@ -895,7 +925,7 @@ class PlatformAutoGen(AutoGen):
                 RetVal[Tool][Attr] = Value
 
         ToolsDef = ''
-        if GlobalData.gOptions.SilentMode and "MAKE" in RetVal:
+        if GlobalData.gArguments.SilentMode and "MAKE" in RetVal:
             if "FLAGS" not in RetVal["MAKE"]:
                 RetVal["MAKE"]["FLAGS"] = ""
             RetVal["MAKE"]["FLAGS"] += " -s"
@@ -946,7 +976,7 @@ class PlatformAutoGen(AutoGen):
 
         return RetVal
 
-    ## Return the paths of tools
+    # Return the paths of tools
     @cached_property
     def ToolDefinitionFile(self):
         tool_def_file = os.path.join(self.MakeFileDir, "TOOLS_DEF." + self.Arch)
@@ -954,15 +984,15 @@ class PlatformAutoGen(AutoGen):
             self.ToolDefinition
         return tool_def_file
 
-    ## Retrieve the toolchain family of given toolchain tag. Default to 'MSFT'.
+    # Retrieve the toolchain family of given toolchain tag. Default to 'MSFT'.
     @cached_property
     def ToolChainFamily(self):
         ToolDefinition = self.Workspace.ToolDef.ToolsDefTxtDatabase
         if TAB_TOD_DEFINES_FAMILY not in ToolDefinition \
            or self.ToolChain not in ToolDefinition[TAB_TOD_DEFINES_FAMILY] \
            or not ToolDefinition[TAB_TOD_DEFINES_FAMILY][self.ToolChain]:
-            EdkLogger.verbose("No tool chain family found in configuration for %s. Default to MSFT." \
-                               % self.ToolChain)
+            EdkLogger.verbose("No tool chain family found in configuration for %s. Default to MSFT."
+                              % self.ToolChain)
             RetVal = TAB_COMPILER_MSFT
         else:
             RetVal = ToolDefinition[TAB_TOD_DEFINES_FAMILY][self.ToolChain]
@@ -974,13 +1004,13 @@ class PlatformAutoGen(AutoGen):
         if TAB_TOD_DEFINES_BUILDRULEFAMILY not in ToolDefinition \
            or self.ToolChain not in ToolDefinition[TAB_TOD_DEFINES_BUILDRULEFAMILY] \
            or not ToolDefinition[TAB_TOD_DEFINES_BUILDRULEFAMILY][self.ToolChain]:
-            EdkLogger.verbose("No tool chain family found in configuration for %s. Default to MSFT." \
-                               % self.ToolChain)
+            EdkLogger.verbose("No tool chain family found in configuration for %s. Default to MSFT."
+                              % self.ToolChain)
             return TAB_COMPILER_MSFT
 
         return ToolDefinition[TAB_TOD_DEFINES_BUILDRULEFAMILY][self.ToolChain]
 
-    ## Return the build options specific for all modules in this platform
+    # Return the build options specific for all modules in this platform
     @cached_property
     def BuildOption(self):
         return self._ExpandBuildOption(self.Platform.BuildOptions)
@@ -988,17 +1018,17 @@ class PlatformAutoGen(AutoGen):
     def _BuildOptionWithToolDef(self, ToolDef):
         return self._ExpandBuildOption(self.Platform.BuildOptions, ToolDef=ToolDef)
 
-    ## Return the build options specific for EDK modules in this platform
+    # Return the build options specific for EDK modules in this platform
     @cached_property
     def EdkBuildOption(self):
         return self._ExpandBuildOption(self.Platform.BuildOptions, EDK_NAME)
 
-    ## Return the build options specific for EDKII modules in this platform
+    # Return the build options specific for EDKII modules in this platform
     @cached_property
     def EdkIIBuildOption(self):
         return self._ExpandBuildOption(self.Platform.BuildOptions, EDKII_NAME)
 
-    ## Parse build_rule.txt in Conf Directory.
+    # Parse build_rule.txt in Conf Directory.
     #
     #   @retval     BuildRule object
     #
@@ -1013,14 +1043,14 @@ class PlatformAutoGen(AutoGen):
         if RetVal._FileVersion == "":
             RetVal._FileVersion = AutoGenReqBuildRuleVerNum
         else:
-            if RetVal._FileVersion < AutoGenReqBuildRuleVerNum :
+            if RetVal._FileVersion < AutoGenReqBuildRuleVerNum:
                 # If Build Rule's version is less than the version number required by the tools, halting the build.
                 EdkLogger.error("build", AUTOGEN_ERROR,
-                                ExtraData="The version number [%s] of build_rule.txt is less than the version number required by the AutoGen.(the minimum required version number is [%s])"\
-                                 % (RetVal._FileVersion, AutoGenReqBuildRuleVerNum))
+                                ExtraData="The version number [%s] of build_rule.txt is less than the version number required by the AutoGen.(the minimum required version number is [%s])"
+                                % (RetVal._FileVersion, AutoGenReqBuildRuleVerNum))
         return RetVal
 
-    ## Summarize the packages used by modules in this platform
+    # Summarize the packages used by modules in this platform
     @cached_property
     def PackageList(self):
         RetVal = set()
@@ -1028,7 +1058,7 @@ class PlatformAutoGen(AutoGen):
             RetVal.update(Mb.Packages)
             for lb in Mb.LibInstances:
                 RetVal.update(lb.Packages)
-        #Collect package set information from INF of FDF
+        # Collect package set information from INF of FDF
         for ModuleFile in self._AsBuildModuleList:
             if ModuleFile in self.Platform.Modules:
                 continue
@@ -1039,23 +1069,23 @@ class PlatformAutoGen(AutoGen):
 
     @cached_property
     def NonDynamicPcdDict(self):
-        return {(Pcd.TokenCName, Pcd.TokenSpaceGuidCName):Pcd for Pcd in self.NonDynamicPcdList}
+        return {(Pcd.TokenCName, Pcd.TokenSpaceGuidCName): Pcd for Pcd in self.NonDynamicPcdList}
 
-    ## Get list of non-dynamic PCDs
+    # Get list of non-dynamic PCDs
     @property
     def NonDynamicPcdList(self):
         if not self._NonDynamicPcdList:
             self.CollectPlatformDynamicPcds()
         return self._NonDynamicPcdList
 
-    ## Get list of dynamic PCDs
+    # Get list of dynamic PCDs
     @property
     def DynamicPcdList(self):
         if not self._DynamicPcdList:
             self.CollectPlatformDynamicPcds()
         return self._DynamicPcdList
 
-    ## Generate Token Number for all PCD
+    # Generate Token Number for all PCD
     @cached_property
     def PcdTokenNumber(self):
         RetVal = OrderedDict()
@@ -1071,25 +1101,29 @@ class PlatformAutoGen(AutoGen):
         #
         for Pcd in self.DynamicPcdList:
             if Pcd.Phase == "PEI" and Pcd.Type in PCD_DYNAMIC_TYPE_SET:
-                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" % (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
+                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" %
+                                (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
                 RetVal[Pcd.TokenCName, Pcd.TokenSpaceGuidCName] = TokenNumber
                 TokenNumber += 1
 
         for Pcd in self.DynamicPcdList:
             if Pcd.Phase == "PEI" and Pcd.Type in PCD_DYNAMIC_EX_TYPE_SET:
-                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" % (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
+                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" %
+                                (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
                 RetVal[Pcd.TokenCName, Pcd.TokenSpaceGuidCName] = TokenNumber
                 TokenNumber += 1
 
         for Pcd in self.DynamicPcdList:
             if Pcd.Phase == "DXE" and Pcd.Type in PCD_DYNAMIC_TYPE_SET:
-                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" % (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
+                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" %
+                                (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
                 RetVal[Pcd.TokenCName, Pcd.TokenSpaceGuidCName] = TokenNumber
                 TokenNumber += 1
 
         for Pcd in self.DynamicPcdList:
             if Pcd.Phase == "DXE" and Pcd.Type in PCD_DYNAMIC_EX_TYPE_SET:
-                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" % (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
+                EdkLogger.debug(EdkLogger.DEBUG_5, "%s %s (%s) -> %d" %
+                                (Pcd.TokenCName, Pcd.TokenSpaceGuidCName, Pcd.Phase, TokenNumber))
                 RetVal[Pcd.TokenCName, Pcd.TokenSpaceGuidCName] = TokenNumber
                 TokenNumber += 1
 
@@ -1111,18 +1145,18 @@ class PlatformAutoGen(AutoGen):
     def _MaList(self):
         for ModuleFile in self.Platform.Modules:
             Ma = ModuleAutoGen(
-                  self.Workspace,
-                  ModuleFile,
-                  self.BuildTarget,
-                  self.ToolChain,
-                  self.Arch,
-                  self.MetaFile,
-                  self.DataPipe
-                  )
+                self.Workspace,
+                ModuleFile,
+                self.BuildTarget,
+                self.ToolChain,
+                self.Arch,
+                self.MetaFile,
+                self.DataPipe
+            )
             self.Platform.Modules[ModuleFile].M = Ma
         return [x.M for x in self.Platform.Modules.values()]
 
-    ## Summarize ModuleAutoGen objects of all modules to be built for this platform
+    # Summarize ModuleAutoGen objects of all modules to be built for this platform
     @cached_property
     def ModuleAutoGenList(self):
         RetVal = []
@@ -1131,7 +1165,7 @@ class PlatformAutoGen(AutoGen):
                 RetVal.append(Ma)
         return RetVal
 
-    ## Summarize ModuleAutoGen objects of all libraries to be built for this platform
+    # Summarize ModuleAutoGen objects of all libraries to be built for this platform
     @cached_property
     def LibraryAutoGenList(self):
         RetVal = []
@@ -1143,7 +1177,7 @@ class PlatformAutoGen(AutoGen):
                     La.ReferenceModules.append(Ma)
         return RetVal
 
-    ## Test if a module is supported by the platform
+    # Test if a module is supported by the platform
     #
     #  An error will be raised directly if the module or its arch is not supported
     #  by the platform or current configuration
@@ -1151,23 +1185,27 @@ class PlatformAutoGen(AutoGen):
     def ValidModule(self, Module):
         return Module in self.Platform.Modules or Module in self.Platform.LibraryInstances \
             or Module in self._AsBuildModuleList
+
     @cached_property
-    def GetAllModuleInfo(self,WithoutPcd=True):
+    def GetAllModuleInfo(self, WithoutPcd=True):
         ModuleLibs = set()
         for m in self.Platform.Modules:
-            module_obj = self.BuildDatabase[m,self.Arch,self.BuildTarget,self.ToolChain]
+            module_obj = self.BuildDatabase[m, self.Arch, self.BuildTarget, self.ToolChain]
             if not bool(module_obj.LibraryClass):
-                Libs = GetModuleLibInstances(module_obj, self.Platform, self.BuildDatabase, self.Arch,self.BuildTarget,self.ToolChain,self.MetaFile,EdkLogger)
+                Libs = GetModuleLibInstances(module_obj, self.Platform, self.BuildDatabase,
+                                             self.Arch, self.BuildTarget, self.ToolChain, self.MetaFile, EdkLogger)
             else:
                 Libs = []
-            ModuleLibs.update( set([(l.MetaFile.File,l.MetaFile.Root,l.MetaFile.Path,l.MetaFile.BaseName,l.MetaFile.OriginalPath,l.Arch,True) for l in Libs]))
+            ModuleLibs.update(set([(l.MetaFile.File, l.MetaFile.Root, l.MetaFile.Path,
+                              l.MetaFile.BaseName, l.MetaFile.OriginalPath, l.Arch, True) for l in Libs]))
             if WithoutPcd and module_obj.PcdIsDriver:
                 continue
-            ModuleLibs.add((m.File,m.Root,m.Path,m.BaseName,m.OriginalPath,module_obj.Arch,bool(module_obj.LibraryClass)))
+            ModuleLibs.add((m.File, m.Root, m.Path, m.BaseName, m.OriginalPath,
+                           module_obj.Arch, bool(module_obj.LibraryClass)))
 
         return ModuleLibs
 
-    ## Resolve the library classes in a module to library instances
+    # Resolve the library classes in a module to library instances
     #
     # This method will not only resolve library classes but also sort the library
     # instances according to the dependency-ship.
@@ -1190,7 +1228,7 @@ class PlatformAutoGen(AutoGen):
                                      self.MetaFile,
                                      EdkLogger)
 
-    ## Override PCD setting (type, value, ...)
+    # Override PCD setting (type, value, ...)
     #
     #   @param  ToPcd       The PCD to be overridden
     #   @param  FromPcd     The PCD overriding from
@@ -1210,15 +1248,15 @@ class PlatformAutoGen(AutoGen):
             if ToPcd.Pending and FromPcd.Type:
                 ToPcd.Type = FromPcd.Type
             elif ToPcd.Type and FromPcd.Type\
-                and ToPcd.Type != FromPcd.Type and ToPcd.Type in FromPcd.Type:
+                    and ToPcd.Type != FromPcd.Type and ToPcd.Type in FromPcd.Type:
                 if ToPcd.Type.strip() == TAB_PCDS_DYNAMIC_EX:
                     ToPcd.Type = FromPcd.Type
             elif ToPcd.Type and FromPcd.Type \
-                and ToPcd.Type != FromPcd.Type:
+                    and ToPcd.Type != FromPcd.Type:
                 if Library:
                     Module = str(Module) + " 's library file (" + str(Library) + ")"
                 EdkLogger.error("build", OPTION_CONFLICT, "Mismatched PCD type",
-                                ExtraData="%s.%s is used as [%s] in module %s, but as [%s] in %s."\
+                                ExtraData="%s.%s is used as [%s] in module %s, but as [%s] in %s."
                                           % (ToPcd.TokenSpaceGuidCName, TokenCName,
                                              ToPcd.Type, Module, FromPcd.Type, Msg),
                                           File=self.MetaFile)
@@ -1239,10 +1277,11 @@ class PlatformAutoGen(AutoGen):
             # Add Flexible PCD format parse
             if ToPcd.DefaultValue:
                 try:
-                    ToPcd.DefaultValue = ValueExpressionEx(ToPcd.DefaultValue, ToPcd.DatumType, self.Platform._GuidDict)(True)
+                    ToPcd.DefaultValue = ValueExpressionEx(
+                        ToPcd.DefaultValue, ToPcd.DatumType, self.Platform._GuidDict)(True)
                 except BadExpression as Value:
-                    EdkLogger.error('Parser', FORMAT_INVALID, 'PCD [%s.%s] Value "%s", %s' %(ToPcd.TokenSpaceGuidCName, ToPcd.TokenCName, ToPcd.DefaultValue, Value),
-                                        File=self.MetaFile)
+                    EdkLogger.error('Parser', FORMAT_INVALID, 'PCD [%s.%s] Value "%s", %s' % (ToPcd.TokenSpaceGuidCName, ToPcd.TokenCName, ToPcd.DefaultValue, Value),
+                                    File=self.MetaFile)
 
             # check the validation of datum
             IsValid, Cause = CheckPcdDatum(ToPcd.DatumType, ToPcd.DefaultValue)
@@ -1255,7 +1294,7 @@ class PlatformAutoGen(AutoGen):
             ToPcd.CustomAttribute = FromPcd.CustomAttribute
 
         if FromPcd is not None and ToPcd.DatumType == TAB_VOID and not ToPcd.MaxDatumSize:
-            EdkLogger.debug(EdkLogger.DEBUG_9, "No MaxDatumSize specified for PCD %s.%s" \
+            EdkLogger.debug(EdkLogger.DEBUG_9, "No MaxDatumSize specified for PCD %s.%s"
                             % (ToPcd.TokenSpaceGuidCName, TokenCName))
             Value = ToPcd.DefaultValue
             if not Value:
@@ -1269,16 +1308,16 @@ class PlatformAutoGen(AutoGen):
 
         # apply default SKU for dynamic PCDS if specified one is not available
         if (ToPcd.Type in PCD_DYNAMIC_TYPE_SET or ToPcd.Type in PCD_DYNAMIC_EX_TYPE_SET) \
-            and not ToPcd.SkuInfoList:
+                and not ToPcd.SkuInfoList:
             if self.Platform.SkuName in self.Platform.SkuIds:
                 SkuName = self.Platform.SkuName
             else:
                 SkuName = TAB_DEFAULT
             ToPcd.SkuInfoList = {
-                SkuName : SkuInfoClass(SkuName, self.Platform.SkuIds[SkuName][0], '', '', '', '', '', ToPcd.DefaultValue)
+                SkuName: SkuInfoClass(SkuName, self.Platform.SkuIds[SkuName][0], '', '', '', '', '', ToPcd.DefaultValue)
             }
 
-    ## Apply PCD setting defined platform to a module
+    # Apply PCD setting defined platform to a module
     #
     #   @param  Module  The module from which the PCD setting will be overridden
     #
@@ -1298,27 +1337,28 @@ class PlatformAutoGen(AutoGen):
             # resolve the VariableGuid value
             for SkuId in PcdInModule.SkuInfoList:
                 Sku = PcdInModule.SkuInfoList[SkuId]
-                if Sku.VariableGuid == '': continue
+                if Sku.VariableGuid == '':
+                    continue
                 Sku.VariableGuidValue = GuidValue(Sku.VariableGuid, self.PackageList, self.MetaFile.Path)
                 if Sku.VariableGuidValue is None:
                     PackageList = "\n\t".join(str(P) for P in self.PackageList)
                     EdkLogger.error(
-                                'build',
-                                RESOURCE_NOT_AVAILABLE,
-                                "Value of GUID [%s] is not found in" % Sku.VariableGuid,
-                                ExtraData=PackageList + "\n\t(used with %s.%s from module %s)" \
-                                                        % (Guid, Name, str(Module)),
-                                File=self.MetaFile
-                                )
+                        'build',
+                        RESOURCE_NOT_AVAILABLE,
+                        "Value of GUID [%s] is not found in" % Sku.VariableGuid,
+                        ExtraData=PackageList + "\n\t(used with %s.%s from module %s)"
+                        % (Guid, Name, str(Module)),
+                        File=self.MetaFile
+                    )
 
         # override PCD settings with module specific setting
         if Module in self.Platform.Modules:
             PlatformModule = self.Platform.Modules[str(Module)]
-            for Key  in PlatformModule.Pcds:
+            for Key in PlatformModule.Pcds:
                 if GlobalData.BuildOptionPcd:
                     for pcd in GlobalData.BuildOptionPcd:
                         (TokenSpaceGuidCName, TokenCName, FieldName, pcdvalue, _) = pcd
-                        if (TokenCName, TokenSpaceGuidCName) == Key and FieldName =="":
+                        if (TokenCName, TokenSpaceGuidCName) == Key and FieldName == "":
                             PlatformModule.Pcds[Key].DefaultValue = pcdvalue
                             PlatformModule.Pcds[Key].PcdValueFromComm = pcdvalue
                             break
@@ -1333,7 +1373,8 @@ class PlatformAutoGen(AutoGen):
                             Flag = True
                             break
                 if Flag:
-                    self._OverridePcd(ToPcd, PlatformModule.Pcds[Key], Module, Msg="DSC Components Module scoped PCD section", Library=Library)
+                    self._OverridePcd(ToPcd, PlatformModule.Pcds[Key], Module,
+                                      Msg="DSC Components Module scoped PCD section", Library=Library)
         # use PCD value to calculate the MaxDatumSize when it is not specified
         for Name, Guid in Pcds:
             Pcd = Pcds[Name, Guid]
@@ -1350,7 +1391,7 @@ class PlatformAutoGen(AutoGen):
                     Pcd.MaxDatumSize = str(len(Value) - 1)
         return list(Pcds.values())
 
-    ## Append build options in platform to a module
+    # Append build options in platform to a module
     #
     #   @param  Module  The module to which the build options will be appended
     #
@@ -1406,8 +1447,7 @@ class PlatformAutoGen(AutoGen):
 
         return BuildOptions, BuildRuleOrder
 
-
-    def GetGlobalBuildOptions(self,Module):
+    def GetGlobalBuildOptions(self, Module):
         ModuleTypeOptions = self.Platform.GetBuildOptionsByModuleType(EDKII_NAME, Module.ModuleType)
         ModuleTypeOptions = self._ExpandBuildOption(ModuleTypeOptions)
 
@@ -1417,39 +1457,41 @@ class PlatformAutoGen(AutoGen):
         else:
             PlatformModuleOptions = {}
 
-        return ModuleTypeOptions,PlatformModuleOptions
-    def ModuleGuid(self,Module):
+        return ModuleTypeOptions, PlatformModuleOptions
+
+    def ModuleGuid(self, Module):
         if os.path.basename(Module.MetaFile.File) != os.path.basename(Module.MetaFile.Path):
             #
             # Length of GUID is 36
             #
             return os.path.basename(Module.MetaFile.Path)[:36]
         return Module.Guid
+
     @cached_property
     def UniqueBaseName(self):
-        retVal ={}
+        retVal = {}
         ModuleNameDict = {}
         UniqueName = {}
         for Module in self._MbList:
-            unique_base_name = '%s_%s' % (Module.BaseName,self.ModuleGuid(Module))
+            unique_base_name = '%s_%s' % (Module.BaseName, self.ModuleGuid(Module))
             if unique_base_name not in ModuleNameDict:
                 ModuleNameDict[unique_base_name] = []
             ModuleNameDict[unique_base_name].append(Module.MetaFile)
             if Module.BaseName not in UniqueName:
                 UniqueName[Module.BaseName] = set()
-            UniqueName[Module.BaseName].add((self.ModuleGuid(Module),Module.MetaFile))
+            UniqueName[Module.BaseName].add((self.ModuleGuid(Module), Module.MetaFile))
         for module_paths in ModuleNameDict.values():
-            if len(set(module_paths))>1:
+            if len(set(module_paths)) > 1:
                 samemodules = list(set(module_paths))
                 EdkLogger.error("build", FILE_DUPLICATED, 'Modules have same BaseName and FILE_GUID:\n'
-                                    '  %s\n  %s' % (samemodules[0], samemodules[1]))
+                                '  %s\n  %s' % (samemodules[0], samemodules[1]))
         for name in UniqueName:
             Guid_Path = UniqueName[name]
             if len(Guid_Path) > 1:
-                for guid,mpath in Guid_Path:
-                    retVal[(name,mpath)] = '%s_%s' % (name,guid)
+                for guid, mpath in Guid_Path:
+                    retVal[(name, mpath)] = '%s_%s' % (name, guid)
         return retVal
-    ## Expand * in build option key
+    # Expand * in build option key
     #
     #   @param  Options     Options to be expanded
     #   @param  ToolDef     Use specified ToolDef instead of full version.
@@ -1459,11 +1501,12 @@ class PlatformAutoGen(AutoGen):
     #
     #   @retval options     Options expanded
     #
+
     def _ExpandBuildOption(self, Options, ModuleStyle=None, ToolDef=None):
         if not ToolDef:
             ToolDef = self.ToolDefinition
         BuildOptions = {}
-        FamilyMatch  = False
+        FamilyMatch = False
         FamilyIsNull = True
 
         OverrideList = {}
@@ -1476,12 +1519,12 @@ class PlatformAutoGen(AutoGen):
             # Key[1] -- TARGET_TOOLCHAIN_ARCH_COMMANDTYPE_ATTRIBUTE
             #
             if (Key[0] == self.BuildRuleFamily and
-                (ModuleStyle is None or len(Key) < 3 or (len(Key) > 2 and Key[2] == ModuleStyle))):
+                    (ModuleStyle is None or len(Key) < 3 or (len(Key) > 2 and Key[2] == ModuleStyle))):
                 Target, ToolChain, Arch, CommandType, Attr = Key[1].split('_')
                 if (Target == self.BuildTarget or Target == TAB_STAR) and\
                     (ToolChain == self.ToolChain or ToolChain == TAB_STAR) and\
                     (Arch == self.Arch or Arch == TAB_STAR) and\
-                    Options[Key].startswith("="):
+                        Options[Key].startswith("="):
 
                     if OverrideList.get(Key[1]) is not None:
                         OverrideList.pop(Key[1])
@@ -1505,7 +1548,7 @@ class PlatformAutoGen(AutoGen):
                         (ToolChain1 == ToolChain2 or ToolChain1 == TAB_STAR or ToolChain2 == TAB_STAR) and\
                         (Arch1 == Arch2 or Arch1 == TAB_STAR or Arch2 == TAB_STAR) and\
                         (CommandType1 == CommandType2 or CommandType1 == TAB_STAR or CommandType2 == TAB_STAR) and\
-                        (Attr1 == Attr2 or Attr1 == TAB_STAR or Attr2 == TAB_STAR):
+                            (Attr1 == Attr2 or Attr1 == TAB_STAR or Attr2 == TAB_STAR):
 
                         if CalculatePriorityValue(NowKey) > CalculatePriorityValue(NextKey):
                             if Options.get((self.BuildRuleFamily, NextKey)) is not None:
@@ -1515,7 +1558,7 @@ class PlatformAutoGen(AutoGen):
                                 Options.pop((self.BuildRuleFamily, NowKey))
 
         for Key in Options:
-            if ModuleStyle is not None and len (Key) > 2:
+            if ModuleStyle is not None and len(Key) > 2:
                 # Check Module style is EDK or EDKII.
                 # Only append build option for the matched style module.
                 if ModuleStyle == EDK_NAME and Key[2] != EDK_NAME:
@@ -1561,7 +1604,7 @@ class PlatformAutoGen(AutoGen):
             return BuildOptions
 
         for Key in Options:
-            if ModuleStyle is not None and len (Key) > 2:
+            if ModuleStyle is not None and len(Key) > 2:
                 # Check Module style is EDK or EDKII.
                 # Only append build option for the matched style module.
                 if ModuleStyle == EDK_NAME and Key[2] != EDK_NAME:

--- a/edk2basetools/Common/GlobalData.py
+++ b/edk2basetools/Common/GlobalData.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # This file is used to define common static strings used by INF/DEC/DSC files
 #
 # Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
@@ -8,7 +8,7 @@ import re
 
 gIsWindows = None
 gWorkspace = "."
-gOptions = None
+gArguments = None
 gCaseInsensitive = False
 gAllFiles = None
 gCommand = None
@@ -35,7 +35,7 @@ gGuidDict = {}
 # definition for a MACRO name.  used to create regular expressions below.
 _MacroNamePattern = "[A-Z][A-Z0-9_]*"
 
-## Regular expression for matching macro used in DSC/DEC/INF file inclusion
+# Regular expression for matching macro used in DSC/DEC/INF file inclusion
 gMacroRefPattern = re.compile("\$\(({})\)".format(_MacroNamePattern), re.UNICODE)
 gMacroDefPattern = re.compile("^(DEFINE|EDK_GLOBAL)[ \t]+")
 gMacroNamePattern = re.compile("^{}$".format(_MacroNamePattern))
@@ -44,18 +44,18 @@ gMacroNamePattern = re.compile("^{}$".format(_MacroNamePattern))
 _HexChar = r"[0-9a-fA-F]"
 _GuidPattern = r"{Hex}{{8}}-{Hex}{{4}}-{Hex}{{4}}-{Hex}{{4}}-{Hex}{{12}}".format(Hex=_HexChar)
 
-## Regular expressions for GUID matching
+# Regular expressions for GUID matching
 gGuidPattern = re.compile(r'{}'.format(_GuidPattern))
 gGuidPatternEnd = re.compile(r'{}$'.format(_GuidPattern))
 
-## Regular expressions for HEX matching
+# Regular expressions for HEX matching
 g4HexChar = re.compile(r'{}{{4}}'.format(_HexChar))
 gHexPattern = re.compile(r'0[xX]{}+'.format(_HexChar))
 gHexPatternAll = re.compile(r'0[xX]{}+$'.format(_HexChar))
 
-## Regular expressions for string identifier checking
+# Regular expressions for string identifier checking
 gIdentifierPattern = re.compile('^[a-zA-Z][a-zA-Z0-9_]*$', re.UNICODE)
-## Regular expression for GUID c structure format
+# Regular expression for GUID c structure format
 _GuidCFormatPattern = r"{{\s*0[xX]{Hex}{{1,8}}\s*,\s*0[xX]{Hex}{{1,4}}\s*,\s*0[xX]{Hex}{{1,4}}" \
                       r"\s*,\s*{{\s*0[xX]{Hex}{{1,2}}\s*,\s*0[xX]{Hex}{{1,2}}" \
                       r"\s*,\s*0[xX]{Hex}{{1,2}}\s*,\s*0[xX]{Hex}{{1,2}}" \
@@ -98,7 +98,7 @@ MixedPcd = {}
 
 # Structure Pcd dict
 gStructurePcd = {}
-gPcdSkuOverrides={}
+gPcdSkuOverrides = {}
 # Pcd name for the Pcd which used in the Conditional directives
 gConditionalPcds = []
 
@@ -122,4 +122,3 @@ gEnableGenfdsMultiThread = True
 gSikpAutoGenCache = set()
 # Common lock for the file access in multiple process AutoGens
 file_lock = None
-

--- a/edk2basetools/PatchPcdValue/PatchPcdValue.py
+++ b/edk2basetools/PatchPcdValue/PatchPcdValue.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # Patch value into the binary file.
 #
 # Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
@@ -12,8 +12,7 @@ import edk2basetools.Common.LongFilePathOs as os
 from edk2basetools.Common.LongFilePathSupport import OpenLongFilePath as open
 import sys
 
-from optparse import OptionParser
-from optparse import make_option
+from argparse import ArgumentParser
 from edk2basetools.Common.BuildToolError import *
 import edk2basetools.Common.EdkLogger as EdkLogger
 from edk2basetools.Common.BuildVersion import gBUILD_VERSION
@@ -22,10 +21,11 @@ from edk2basetools.Common.DataType import *
 
 # Version and Copyright
 __version_number__ = ("0.10" + " " + gBUILD_VERSION)
-__version__ = "%prog Version " + __version_number__
+__version__ = "%(prog)s Version " + __version_number__
 __copyright__ = "Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved."
 
-## PatchBinaryFile method
+
+# PatchBinaryFile method
 #
 # This method mainly patches the data into binary file.
 #
@@ -43,7 +43,7 @@ def PatchBinaryFile(FileName, ValueOffset, TypeName, ValueString, MaxSize=0):
     # Length of Binary File
     #
     FileHandle = open(FileName, 'rb')
-    FileHandle.seek (0, 2)
+    FileHandle.seek(0, 2)
     FileLength = FileHandle.tell()
     FileHandle.close()
     #
@@ -104,7 +104,7 @@ def PatchBinaryFile(FileName, ValueOffset, TypeName, ValueString, MaxSize=0):
                 ValueNumber = 1
             elif ValueString == 'FALSE':
                 ValueNumber = 0
-            ValueNumber = int (ValueString, 0)
+            ValueNumber = int(ValueString, 0)
             if ValueNumber != 0:
                 ValueNumber = 1
         except:
@@ -118,7 +118,7 @@ def PatchBinaryFile(FileName, ValueOffset, TypeName, ValueString, MaxSize=0):
         # Get PCD value for UINT* data type
         #
         try:
-            ValueNumber = int (ValueString, 0)
+            ValueNumber = int(ValueString, 0)
         except:
             return PARAMETER_INVALID, "PCD Value %s is not valid dec or hex string." % (ValueString)
         #
@@ -149,7 +149,7 @@ def PatchBinaryFile(FileName, ValueOffset, TypeName, ValueString, MaxSize=0):
             #
             # Patch {0x1, 0x2, ...} byte by byte
             #
-            ValueList = ValueString[1 : len(ValueString) - 1].split(',')
+            ValueList = ValueString[1: len(ValueString) - 1].split(',')
             Index = 0
             try:
                 for ByteString in ValueList:
@@ -191,48 +191,48 @@ def PatchBinaryFile(FileName, ValueOffset, TypeName, ValueString, MaxSize=0):
         FileHandle.close()
     return 0, "Patch Value into File %s successfully." % (FileName)
 
-## Parse command line options
+# Parse command line options
 #
 # Using standard Python module optparse to parse command line option of this tool.
 #
 # @retval Options   A optparse.Values object containing the parsed options
 # @retval InputFile Path of file to be trimmed
 #
+
+
 def Options():
-    OptionList = [
-        make_option("-f", "--offset", dest="PcdOffset", action="store", type="int",
-                          help="Start offset to the image is used to store PCD value."),
-        make_option("-u", "--value", dest="PcdValue", action="store",
-                          help="PCD value will be updated into the image."),
-        make_option("-t", "--type", dest="PcdTypeName", action="store",
-                          help="The name of PCD data type may be one of VOID*,BOOLEAN, UINT8, UINT16, UINT32, UINT64."),
-        make_option("-s", "--maxsize", dest="PcdMaxSize", action="store", type="int",
-                          help="Max size of data buffer is taken by PCD value.It must be set when PCD type is VOID*."),
-        make_option("-v", "--verbose", dest="LogLevel", action="store_const", const=EdkLogger.VERBOSE,
-                          help="Run verbosely"),
-        make_option("-d", "--debug", dest="LogLevel", type="int",
-                          help="Run with debug information"),
-        make_option("-q", "--quiet", dest="LogLevel", action="store_const", const=EdkLogger.QUIET,
-                          help="Run quietly"),
-        make_option("-?", action="help", help="show this help message and exit"),
-    ]
-
     # use clearer usage to override default usage message
-    UsageString = "%prog -f Offset -u Value -t Type [-s MaxSize] <input_file>"
+    UsageString = "%(prog)s -f Offset -u Value -t Type [-s MaxSize] <input_file>"
 
-    Parser = OptionParser(description=__copyright__, version=__version__, option_list=OptionList, usage=UsageString)
+    Parser = ArgumentParser(description=__copyright__, usage=UsageString)
+
+    Parser.add_argument("input_file", metavar="INPUT FILE", type=str)
+
+    Parser.add_argument('--version', action='version', version=__version__)
+    Parser.add_argument("-f", "--offset", dest="PcdOffset", type=int, required=True,
+                        help="Start offset to the image is used to store PCD value."),
+    Parser.add_argument("-u", "--value", dest="PcdValue", type=str, required=True,
+                        help="PCD value will be updated into the image."),
+    Parser.add_argument("-t", "--type", dest="PcdTypeName", type=str.upper, required=True, choices=TAB_PCD_NUMERIC_TYPES_VOID,
+                        help="The name of PCD data type may be one of VOID*,BOOLEAN, UINT8, UINT16, UINT32, UINT64."),
+    Parser.add_argument("-s", "--maxsize", dest="PcdMaxSize", type=int,
+                        help="Max size of data buffer is taken by PCD value.It must be set when PCD type is VOID*."),
+    Parser.add_argument("-v", "--verbose", dest="LogLevel", action="store_const", const=EdkLogger.VERBOSE,
+                        help="Run verbosely"),
+    Parser.add_argument("-d", "--debug", dest="LogLevel", type=int,
+                        help="Run with debug information"),
+    Parser.add_argument("-q", "--quiet", dest="LogLevel", action="store_const", const=EdkLogger.QUIET,
+                        help="Run quietly"),
+    Parser.add_argument("-?", action="help", help="show this help message and exit"),
+
     Parser.set_defaults(LogLevel=EdkLogger.INFO)
 
-    Options, Args = Parser.parse_args()
+    Arguments = Parser.parse_args()
 
-    # error check
-    if len(Args) == 0:
-        EdkLogger.error("PatchPcdValue", PARAMETER_INVALID, ExtraData=Parser.get_usage())
-
-    InputFile = Args[len(Args) - 1]
+    InputFile = Arguments.input_file
     return Options, InputFile
 
-## Entrance method
+# Entrance method
 #
 # This method mainly dispatch specific methods per the command line options.
 # If no error found, return zero value so the caller of this tool can know
@@ -241,6 +241,8 @@ def Options():
 # @retval 0     Tool was successful
 # @retval 1     Tool failed
 #
+
+
 def Main():
     try:
         #
@@ -252,28 +254,25 @@ def Main():
             EdkLogger.SetLevel(CommandOptions.LogLevel + 1)
         else:
             EdkLogger.SetLevel(CommandOptions.LogLevel)
-        if not os.path.exists (InputFile):
+        if not os.path.exists(InputFile):
             EdkLogger.error("PatchPcdValue", FILE_NOT_FOUND, ExtraData=InputFile)
             return 1
-        if CommandOptions.PcdOffset is None or CommandOptions.PcdValue is None or CommandOptions.PcdTypeName is None:
-            EdkLogger.error("PatchPcdValue", OPTION_MISSING, ExtraData="PcdOffset or PcdValue of PcdTypeName is not specified.")
-            return 1
-        if CommandOptions.PcdTypeName.upper() not in TAB_PCD_NUMERIC_TYPES_VOID:
-            EdkLogger.error("PatchPcdValue", PARAMETER_INVALID, ExtraData="PCD type %s is not valid." % (CommandOptions.PcdTypeName))
-            return 1
-        if CommandOptions.PcdTypeName.upper() == TAB_VOID and CommandOptions.PcdMaxSize is None:
-            EdkLogger.error("PatchPcdValue", OPTION_MISSING, ExtraData="PcdMaxSize is not specified for VOID* type PCD.")
+        if CommandOptions.PcdTypeName == TAB_VOID and CommandOptions.PcdMaxSize is None:
+            EdkLogger.error("PatchPcdValue", OPTION_MISSING,
+                            ExtraData="PcdMaxSize is not specified for VOID* type PCD.")
             return 1
         #
         # Patch value into binary image.
         #
-        ReturnValue, ErrorInfo = PatchBinaryFile (InputFile, CommandOptions.PcdOffset, CommandOptions.PcdTypeName, CommandOptions.PcdValue, CommandOptions.PcdMaxSize)
+        ReturnValue, ErrorInfo = PatchBinaryFile(
+            InputFile, CommandOptions.PcdOffset, CommandOptions.PcdTypeName, CommandOptions.PcdValue, CommandOptions.PcdMaxSize)
         if ReturnValue != 0:
             EdkLogger.error("PatchPcdValue", ReturnValue, ExtraData=ErrorInfo)
             return 1
         return 0
     except:
         return 1
+
 
 if __name__ == '__main__':
     r = Main()

--- a/edk2basetools/TargetTool/TargetTool.py
+++ b/edk2basetools/TargetTool/TargetTool.py
@@ -185,7 +185,7 @@ __usage__ = "%(prog)s [options] {args} \
 def MyOptionParser():
     parser = ArgumentParser(prog="TargetTool.exe", usage=__usage__, description=__copyright__)
 
-    parser.add_argument("Arg", metavar="ARG", type=str, choices=['clean', 'print', 'set'])
+    parser.add_argument("Arg", metavar="ARG", type=str.lower, choices=['clean', 'print', 'set'])
 
     parser.add_argument('--version', action='version', version=__version__)
     parser.add_argument("-a", "--arch", action="append", dest="TARGET_ARCH", type=str, choices=['IA32', 'X64', 'ARM', 'AARCH64', 'EBC'],

--- a/edk2basetools/Trim/Trim.py
+++ b/edk2basetools/Trim/Trim.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # Trim files preprocessed by compiler
 #
 # Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
@@ -13,8 +13,7 @@ import sys
 import re
 from io import BytesIO
 import codecs
-from optparse import OptionParser
-from optparse import make_option
+from argparse import ArgumentParser
 from edk2basetools.Common.BuildToolError import *
 from edk2basetools.Common.Misc import *
 from edk2basetools.Common.DataType import *
@@ -24,18 +23,18 @@ from edk2basetools.Common.LongFilePathSupport import OpenLongFilePath as open
 
 # Version and Copyright
 __version_number__ = ("0.10" + " " + gBUILD_VERSION)
-__version__ = "%prog Version " + __version_number__
+__version__ = "%(prog)s Version " + __version_number__
 __copyright__ = "Copyright (c) 2007-2018, Intel Corporation. All rights reserved."
 
-## Regular expression for matching Line Control directive like "#line xxx"
+# Regular expression for matching Line Control directive like "#line xxx"
 gLineControlDirective = re.compile('^\s*#(?:line)?\s+([0-9]+)\s+"*([^"]*)"')
-## Regular expression for matching "typedef struct"
+# Regular expression for matching "typedef struct"
 gTypedefPattern = re.compile("^\s*typedef\s+struct(\s+\w+)?\s*[{]*$", re.MULTILINE)
-## Regular expression for matching "#pragma pack"
+# Regular expression for matching "#pragma pack"
 gPragmaPattern = re.compile("^\s*#pragma\s+pack", re.MULTILINE)
-## Regular expression for matching "typedef"
+# Regular expression for matching "typedef"
 gTypedef_SinglePattern = re.compile("^\s*typedef", re.MULTILINE)
-## Regular expression for matching "typedef struct, typedef union, struct, union"
+# Regular expression for matching "typedef struct, typedef union, struct, union"
 gTypedef_MulPattern = re.compile("^\s*(typedef)?\s+(struct|union)(\s+\w+)?\s*[{]*$", re.MULTILINE)
 
 #
@@ -43,27 +42,28 @@ gTypedef_MulPattern = re.compile("^\s*(typedef)?\s+(struct|union)(\s+\w+)?\s*[{]
 # There is leading non-(alphanumeric or _) character, and no following alphanumeric or _
 # as the pattern is greedily match, so it is ok for the gDecNumberPattern or gHexNumberPattern to grab the maximum match
 #
-## Regular expression for matching HEX number
+# Regular expression for matching HEX number
 gHexNumberPattern = re.compile("(?<=[^a-zA-Z0-9_])(0[xX])([0-9a-fA-F]+)(U(?=$|[^a-zA-Z0-9_]))?")
-## Regular expression for matching decimal number with 'U' postfix
+# Regular expression for matching decimal number with 'U' postfix
 gDecNumberPattern = re.compile("(?<=[^a-zA-Z0-9_])([0-9]+)U(?=$|[^a-zA-Z0-9_])")
-## Regular expression for matching constant with 'ULL' 'LL' postfix
+# Regular expression for matching constant with 'ULL' 'LL' postfix
 gLongNumberPattern = re.compile("(?<=[^a-zA-Z0-9_])(0[xX][0-9a-fA-F]+|[0-9]+)U?LL(?=$|[^a-zA-Z0-9_])")
 
-## Regular expression for matching "Include ()" in asl file
+# Regular expression for matching "Include ()" in asl file
 gAslIncludePattern = re.compile("^(\s*)[iI]nclude\s*\(\"?([^\"\(\)]+)\"\)", re.MULTILINE)
-## Regular expression for matching C style #include "XXX.asl" in asl file
+# Regular expression for matching C style #include "XXX.asl" in asl file
 gAslCIncludePattern = re.compile(r'^(\s*)#include\s*[<"]\s*([-\\/\w.]+)\s*([>"])', re.MULTILINE)
-## Patterns used to convert EDK conventions to EDK2 ECP conventions
+# Patterns used to convert EDK conventions to EDK2 ECP conventions
 
-## Regular expression for finding header file inclusions
-gIncludePattern = re.compile(r"^[ \t]*[%]?[ \t]*include(?:[ \t]*(?:\\(?:\r\n|\r|\n))*[ \t]*)*(?:\(?[\"<]?[ \t]*)([-\w.\\/() \t]+)(?:[ \t]*[\">]?\)?)", re.MULTILINE | re.UNICODE | re.IGNORECASE)
+# Regular expression for finding header file inclusions
+gIncludePattern = re.compile(
+    r"^[ \t]*[%]?[ \t]*include(?:[ \t]*(?:\\(?:\r\n|\r|\n))*[ \t]*)*(?:\(?[\"<]?[ \t]*)([-\w.\\/() \t]+)(?:[ \t]*[\">]?\)?)", re.MULTILINE | re.UNICODE | re.IGNORECASE)
 
 
-## file cache to avoid circular include in ASL file
+# file cache to avoid circular include in ASL file
 gIncludedAslFile = []
 
-## Trim preprocessed source code
+# Trim preprocessed source code
 #
 # Remove extra content made by preprocessor. The preprocessor must enable the
 # line number generation option when preprocessing.
@@ -72,6 +72,8 @@ gIncludedAslFile = []
 # @param  Target    File to store the trimmed content
 # @param  Convert   If True, convert standard HEX format to MASM format
 #
+
+
 def TrimPreprocessedFile(Source, Target, ConvertHex, TrimLong):
     CreateDirectory(os.path.dirname(Target))
     try:
@@ -137,7 +139,7 @@ def TrimPreprocessedFile(Source, Target, ConvertHex, TrimLong):
                 NewLines[LineNumber - 1] = Line
             else:
                 if LineNumber > (len(NewLines) + 1):
-                    for LineIndex in range(len(NewLines), LineNumber-1):
+                    for LineIndex in range(len(NewLines), LineNumber - 1):
                         NewLines.append(TAB_LINE_BREAK)
                 NewLines.append(Line)
             LineNumber = None
@@ -183,7 +185,7 @@ def TrimPreprocessedFile(Source, Target, ConvertHex, TrimLong):
     except:
         EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=Target)
 
-## Trim preprocessed VFR file
+# Trim preprocessed VFR file
 #
 # Remove extra content made by preprocessor. The preprocessor doesn't need to
 # enable line number generation option when preprocessing.
@@ -191,6 +193,8 @@ def TrimPreprocessedFile(Source, Target, ConvertHex, TrimLong):
 # @param  Source    File to be trimmed
 # @param  Target    File to store the trimmed content
 #
+
+
 def TrimPreprocessedVfr(Source, Target):
     CreateDirectory(os.path.dirname(Target))
 
@@ -238,7 +242,7 @@ def TrimPreprocessedVfr(Source, Target):
             TypedefEnd = Index
             # keep all "typedef struct" except to GUID, EFI_PLABEL and PAL_CALL_RETURN
             if Line.strip("} ;\r\n") in [TAB_GUID, "EFI_PLABEL", "PAL_CALL_RETURN"]:
-                for i in range(TypedefStart, TypedefEnd+1):
+                for i in range(TypedefStart, TypedefEnd + 1):
                     Lines[i] = "\n"
 
     # save all lines trimmed
@@ -248,7 +252,7 @@ def TrimPreprocessedVfr(Source, Target):
     except:
         EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=Target)
 
-## Read the content  ASL file, including ASL included, recursively
+# Read the content  ASL file, including ASL included, recursively
 #
 # @param  Source            File to be read
 # @param  Indent            Spaces before the Include() statement
@@ -257,7 +261,9 @@ def TrimPreprocessedVfr(Source, Target):
 #                           first for the included file; otherwise, only the path specified
 #                           in the IncludePathList will be searched.
 #
-def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, IncludeFileList = None, filetype=None):
+
+
+def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, IncludeFileList=None, filetype=None):
     NewFileContent = []
     if IncludeFileList is None:
         IncludeFileList = []
@@ -287,12 +293,11 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
         EdkLogger.warn("Trim", FILE_OPEN_FAILURE, ExtraData=Source)
         return []
 
-
     # avoid A "include" B and B "include" A
     IncludeFile = os.path.abspath(os.path.normpath(IncludeFile))
     if IncludeFile in gIncludedAslFile:
         EdkLogger.warn("Trim", "Circular include",
-                       ExtraData= "%s -> %s" % (" -> ".join(gIncludedAslFile), IncludeFile))
+                       ExtraData="%s -> %s" % (" -> ".join(gIncludedAslFile), IncludeFile))
         return []
     gIncludedAslFile.append(IncludeFile)
     IncludeFileList.append(IncludeFile.strip())
@@ -312,7 +317,8 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
                     LocalSearchPath = os.path.dirname(IncludeFile)
             CurrentIndent = Indent + Result[0][0]
             IncludedFile = Result[0][1]
-            NewFileContent.extend(DoInclude(IncludedFile, CurrentIndent, IncludePathList, LocalSearchPath,IncludeFileList,filetype))
+            NewFileContent.extend(DoInclude(IncludedFile, CurrentIndent, IncludePathList,
+                                  LocalSearchPath, IncludeFileList, filetype))
             NewFileContent.append("\n")
         elif filetype == "ASM":
             Result = gIncludePattern.findall(Line)
@@ -324,7 +330,8 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
 
             IncludedFile = IncludedFile.strip()
             IncludedFile = os.path.normpath(IncludedFile)
-            NewFileContent.extend(DoInclude(IncludedFile, '', IncludePathList, LocalSearchPath,IncludeFileList,filetype))
+            NewFileContent.extend(DoInclude(IncludedFile, '', IncludePathList,
+                                  LocalSearchPath, IncludeFileList, filetype))
             NewFileContent.append("\n")
 
     gIncludedAslFile.pop()
@@ -332,7 +339,7 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
     return NewFileContent
 
 
-## Trim ASL file
+# Trim ASL file
 #
 # Replace ASL include statement with the content the included file
 #
@@ -340,7 +347,7 @@ def DoInclude(Source, Indent='', IncludePathList=[], LocalSearchPath=None, Inclu
 # @param  Target          File to store the trimmed content
 # @param  IncludePathFile The file to log the external include path
 #
-def TrimAslFile(Source, Target, IncludePathFile,AslDeps = False):
+def TrimAslFile(Source, Target, IncludePathFile, AslDeps=False):
     CreateDirectory(os.path.dirname(Target))
 
     SourceDir = os.path.dirname(Source)
@@ -363,16 +370,17 @@ def TrimAslFile(Source, Target, IncludePathFile,AslDeps = False):
                 FileLines = File.readlines()
             for Line in FileLines:
                 LineNum += 1
-                if Line.startswith("/I") or Line.startswith ("-I"):
+                if Line.startswith("/I") or Line.startswith("-I"):
                     IncludePathList.append(Line[2:].strip())
                 else:
                     EdkLogger.warn("Trim", "Invalid include line in include list file.", IncludePathFile, LineNum)
         except:
             EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=IncludePathFile)
     AslIncludes = []
-    Lines = DoInclude(Source, '', IncludePathList,IncludeFileList=AslIncludes,filetype='ASL')
-    AslIncludes = [item for item in AslIncludes if item !=Source]
-    SaveFileOnChange(os.path.join(os.path.dirname(Target),os.path.basename(Source))+".trim.deps", " \\\n".join([Source+":"] +AslIncludes),False)
+    Lines = DoInclude(Source, '', IncludePathList, IncludeFileList=AslIncludes, filetype='ASL')
+    AslIncludes = [item for item in AslIncludes if item != Source]
+    SaveFileOnChange(os.path.join(os.path.dirname(Target), os.path.basename(Source)) +
+                     ".trim.deps", " \\\n".join([Source + ":"] + AslIncludes), False)
 
     #
     # Undef MIN and MAX to avoid collision in ASL source code
@@ -386,7 +394,7 @@ def TrimAslFile(Source, Target, IncludePathFile,AslDeps = False):
     except:
         EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=Target)
 
-## Trim ASM file
+# Trim ASM file
 #
 # Output ASM include statement with the content the included file
 #
@@ -394,6 +402,8 @@ def TrimAslFile(Source, Target, IncludePathFile,AslDeps = False):
 # @param  Target          File to store the trimmed content
 # @param  IncludePathFile The file to log the external include path
 #
+
+
 def TrimAsmFile(Source, Target, IncludePathFile):
     CreateDirectory(os.path.dirname(Target))
 
@@ -416,23 +426,25 @@ def TrimAsmFile(Source, Target, IncludePathFile):
                 FileLines = File.readlines()
             for Line in FileLines:
                 LineNum += 1
-                if Line.startswith("/I") or Line.startswith ("-I"):
+                if Line.startswith("/I") or Line.startswith("-I"):
                     IncludePathList.append(Line[2:].strip())
                 else:
                     EdkLogger.warn("Trim", "Invalid include line in include list file.", IncludePathFile, LineNum)
         except:
             EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=IncludePathFile)
     AsmIncludes = []
-    Lines = DoInclude(Source, '', IncludePathList,IncludeFileList=AsmIncludes,filetype='ASM')
+    Lines = DoInclude(Source, '', IncludePathList, IncludeFileList=AsmIncludes, filetype='ASM')
     AsmIncludes = [item for item in AsmIncludes if item != Source]
     if AsmIncludes:
-        SaveFileOnChange(os.path.join(os.path.dirname(Target),os.path.basename(Source))+".trim.deps", " \\\n".join([Source+":"] +AsmIncludes),False)
+        SaveFileOnChange(os.path.join(os.path.dirname(Target), os.path.basename(Source)) +
+                         ".trim.deps", " \\\n".join([Source + ":"] + AsmIncludes), False)
     # save all lines trimmed
     try:
         with open(Target, 'w') as File:
             File.writelines(Lines)
     except:
         EdkLogger.error("Trim", FILE_OPEN_FAILURE, ExtraData=Target)
+
 
 def GenerateVfrBinSec(ModuleName, DebugDir, OutputFile):
     VfrNameList = []
@@ -441,9 +453,9 @@ def GenerateVfrBinSec(ModuleName, DebugDir, OutputFile):
             for FileName in Files:
                 Name, Ext = os.path.splitext(FileName)
                 if Ext == '.c' and Name != 'AutoGen':
-                    VfrNameList.append (Name + 'Bin')
+                    VfrNameList.append(Name + 'Bin')
 
-    VfrNameList.append (ModuleName + 'Strings')
+    VfrNameList.append(ModuleName + 'Strings')
 
     EfiFileName = os.path.join(DebugDir, ModuleName + '.efi')
     MapFileName = os.path.join(DebugDir, ModuleName + '.map')
@@ -455,7 +467,7 @@ def GenerateVfrBinSec(ModuleName, DebugDir, OutputFile):
     try:
         fInputfile = open(OutputFile, "wb+")
     except:
-        EdkLogger.error("Trim", FILE_OPEN_FAILURE, "File open failed for %s" %OutputFile, None)
+        EdkLogger.error("Trim", FILE_OPEN_FAILURE, "File open failed for %s" % OutputFile, None)
 
     # Use a instance of BytesIO to cache data
     fStringIO = BytesIO()
@@ -469,8 +481,8 @@ def GenerateVfrBinSec(ModuleName, DebugDir, OutputFile):
             #
             UniGuid = b'\xe0\xc5\x13\x89\xf63\x86M\x9b\xf1C\xef\x89\xfc\x06f'
             fStringIO.write(UniGuid)
-            UniValue = pack ('Q', int (Item[1], 16))
-            fStringIO.write (UniValue)
+            UniValue = pack('Q', int(Item[1], 16))
+            fStringIO.write(UniValue)
         else:
             #
             # VFR binary offset in image.
@@ -479,23 +491,24 @@ def GenerateVfrBinSec(ModuleName, DebugDir, OutputFile):
             #
             VfrGuid = b'\xb4|\xbc\xd0Gj_I\xaa\x11q\x07F\xda\x06\xa2'
             fStringIO.write(VfrGuid)
-            type (Item[1])
-            VfrValue = pack ('Q', int (Item[1], 16))
-            fStringIO.write (VfrValue)
+            type(Item[1])
+            VfrValue = pack('Q', int(Item[1], 16))
+            fStringIO.write(VfrValue)
 
     #
     # write data into file.
     #
-    try :
-        fInputfile.write (fStringIO.getvalue())
+    try:
+        fInputfile.write(fStringIO.getvalue())
     except:
-        EdkLogger.error("Trim", FILE_WRITE_FAILURE, "Write data to file %s failed, please check whether the file been locked or using by other applications." %OutputFile, None)
+        EdkLogger.error("Trim", FILE_WRITE_FAILURE,
+                        "Write data to file %s failed, please check whether the file been locked or using by other applications." % OutputFile, None)
 
-    fStringIO.close ()
-    fInputfile.close ()
+    fStringIO.close()
+    fInputfile.close()
 
 
-## Parse command line options
+# Parse command line options
 #
 # Using standard Python module optparse to parse command line option of this tool.
 #
@@ -503,65 +516,64 @@ def GenerateVfrBinSec(ModuleName, DebugDir, OutputFile):
 # @retval InputFile Path of file to be trimmed
 #
 def Options():
-    OptionList = [
-        make_option("-s", "--source-code", dest="FileType", const="SourceCode", action="store_const",
-                          help="The input file is preprocessed source code, including C or assembly code"),
-        make_option("-r", "--vfr-file", dest="FileType", const="Vfr", action="store_const",
-                          help="The input file is preprocessed VFR file"),
-        make_option("--Vfr-Uni-Offset", dest="FileType", const="VfrOffsetBin", action="store_const",
-                          help="The input file is EFI image"),
-        make_option("--asl-deps", dest="AslDeps", const="True", action="store_const",
-                          help="Generate Asl dependent files."),
-        make_option("-a", "--asl-file", dest="FileType", const="Asl", action="store_const",
-                          help="The input file is ASL file"),
-        make_option( "--asm-file", dest="FileType", const="Asm", action="store_const",
-                          help="The input file is asm file"),
-        make_option("-c", "--convert-hex", dest="ConvertHex", action="store_true",
-                          help="Convert standard hex format (0xabcd) to MASM format (abcdh)"),
-
-        make_option("-l", "--trim-long", dest="TrimLong", action="store_true",
-                          help="Remove postfix of long number"),
-        make_option("-i", "--include-path-file", dest="IncludePathFile",
-                          help="The input file is include path list to search for ASL include file"),
-        make_option("-o", "--output", dest="OutputFile",
-                          help="File to store the trimmed content"),
-        make_option("--ModuleName", dest="ModuleName", help="The module's BASE_NAME"),
-        make_option("--DebugDir", dest="DebugDir",
-                          help="Debug Output directory to store the output files"),
-        make_option("-v", "--verbose", dest="LogLevel", action="store_const", const=EdkLogger.VERBOSE,
-                          help="Run verbosely"),
-        make_option("-d", "--debug", dest="LogLevel", type="int",
-                          help="Run with debug information"),
-        make_option("-q", "--quiet", dest="LogLevel", action="store_const", const=EdkLogger.QUIET,
-                          help="Run quietly"),
-        make_option("-?", action="help", help="show this help message and exit"),
-    ]
-
     # use clearer usage to override default usage message
-    UsageString = "%prog [-s|-r|-a|--Vfr-Uni-Offset] [-c] [-v|-d <debug_level>|-q] [-i <include_path_file>] [-o <output_file>] [--ModuleName <ModuleName>] [--DebugDir <DebugDir>] [<input_file>]"
+    UsageString = "%(prog)s [-s|-r|-a|--Vfr-Uni-Offset] [-c] [-v|-d <debug_level>|-q] [-i <include_path_file>] [-o <output_file>] [--ModuleName <ModuleName>] [--DebugDir <DebugDir>] [<input_file>]"
 
-    Parser = OptionParser(description=__copyright__, version=__version__, option_list=OptionList, usage=UsageString)
+    Parser = ArgumentParser(description=__copyright__, usage=UsageString)
+
+    Parser.add_argument("input_file", nargs='?', type=str)
+
+    Parser.add_argument('--version', action='version', version=__version__)
+    Parser.add_argument("-s", "--source-code", dest="FileType", const="SourceCode", action="store_const",
+                        help="The input file is preprocessed source code, including C or assembly code"),
+    Parser.add_argument("-r", "--vfr-file", dest="FileType", const="Vfr", action="store_const",
+                        help="The input file is preprocessed VFR file"),
+    Parser.add_argument("--Vfr-Uni-Offset", dest="FileType", const="VfrOffsetBin", action="store_const",
+                        help="The input file is EFI image"),
+    Parser.add_argument("--asl-deps", dest="AslDeps", const="True", action="store_const",
+                        help="Generate Asl dependent files."),
+    Parser.add_argument("-a", "--asl-file", dest="FileType", const="Asl", action="store_const",
+                        help="The input file is ASL file"),
+    Parser.add_argument("--asm-file", dest="FileType", const="Asm", action="store_const",
+                        help="The input file is asm file"),
+    Parser.add_argument("-c", "--convert-hex", dest="ConvertHex", action="store_true",
+                        help="Convert standard hex format (0xabcd) to MASM format (abcdh)"),
+    Parser.add_argument("-l", "--trim-long", dest="TrimLong", action="store_true",
+                        help="Remove postfix of long number"),
+    Parser.add_argument("-i", "--include-path-file", dest="IncludePathFile", type=str,
+                        help="The input file is include path list to search for ASL include file"),
+    Parser.add_argument("-o", "--output", dest="OutputFile", type=str,
+                        help="File to store the trimmed content"),
+    Parser.add_argument("--ModuleName", dest="ModuleName", type=str, help="The module's BASE_NAME"),
+    Parser.add_argument("--DebugDir", dest="DebugDir", type=str,
+                        help="Debug Output directory to store the output files"),
+    Parser.add_argument("-v", "--verbose", dest="LogLevel", action="store_const", const=EdkLogger.VERBOSE,
+                        help="Run verbosely"),
+    Parser.add_argument("-d", "--debug", dest="LogLevel", type=int,
+                        help="Run with debug information"),
+    Parser.add_argument("-q", "--quiet", dest="LogLevel", action="store_const", const=EdkLogger.QUIET,
+                        help="Run quietly"),
+    Parser.add_argument("-?", action="help", help="show this help message and exit"),
+
     Parser.set_defaults(FileType="Vfr")
     Parser.set_defaults(ConvertHex=False)
     Parser.set_defaults(LogLevel=EdkLogger.INFO)
 
-    Options, Args = Parser.parse_args()
+    Arguments = Parser.parse_args()
+
+    InputFile = Arguments.input_file
 
     # error check
-    if Options.FileType == 'VfrOffsetBin':
-        if len(Args) == 0:
+    if Arguments.FileType == 'VfrOffsetBin':
+        if InputFile is None:
             return Options, ''
-        elif len(Args) > 1:
-            EdkLogger.error("Trim", OPTION_NOT_SUPPORTED, ExtraData=Parser.get_usage())
-    if len(Args) == 0:
-        EdkLogger.error("Trim", OPTION_MISSING, ExtraData=Parser.get_usage())
-    if len(Args) > 1:
-        EdkLogger.error("Trim", OPTION_NOT_SUPPORTED, ExtraData=Parser.get_usage())
 
-    InputFile = Args[0]
+    if InputFile is None:
+        EdkLogger.error("Trim", OPTION_MISSING, ExtraData=Parser.format_usage())
+
     return Options, InputFile
 
-## Entrance method
+# Entrance method
 #
 # This method mainly dispatch specific methods per the command line options.
 # If no error found, return zero value so the caller of this tool can know
@@ -570,6 +582,8 @@ def Options():
 # @retval 0     Tool was successful
 # @retval 1     Tool failed
 #
+
+
 def Main():
     try:
         EdkLogger.Initialize()
@@ -589,15 +603,16 @@ def Main():
         elif CommandOptions.FileType == "Asl":
             if CommandOptions.OutputFile is None:
                 CommandOptions.OutputFile = os.path.splitext(InputFile)[0] + '.iii'
-            TrimAslFile(InputFile, CommandOptions.OutputFile, CommandOptions.IncludePathFile,CommandOptions.AslDeps)
+            TrimAslFile(InputFile, CommandOptions.OutputFile, CommandOptions.IncludePathFile, CommandOptions.AslDeps)
         elif CommandOptions.FileType == "VfrOffsetBin":
             GenerateVfrBinSec(CommandOptions.ModuleName, CommandOptions.DebugDir, CommandOptions.OutputFile)
         elif CommandOptions.FileType == "Asm":
             TrimAsmFile(InputFile, CommandOptions.OutputFile, CommandOptions.IncludePathFile)
-        else :
+        else:
             if CommandOptions.OutputFile is None:
                 CommandOptions.OutputFile = os.path.splitext(InputFile)[0] + '.iii'
-            TrimPreprocessedFile(InputFile, CommandOptions.OutputFile, CommandOptions.ConvertHex, CommandOptions.TrimLong)
+            TrimPreprocessedFile(InputFile, CommandOptions.OutputFile,
+                                 CommandOptions.ConvertHex, CommandOptions.TrimLong)
     except FatalError as X:
         import platform
         import traceback
@@ -608,20 +623,21 @@ def Main():
         import traceback
         import platform
         EdkLogger.error(
-                    "\nTrim",
-                    CODE_ERROR,
-                    "Unknown fatal error when trimming [%s]" % InputFile,
-                    ExtraData="\n(Please send email to %s for help, attaching following call stack trace!)\n" % MSG_EDKII_MAIL_ADDR,
-                    RaiseError=False
-                    )
+            "\nTrim",
+            CODE_ERROR,
+            "Unknown fatal error when trimming [%s]" % InputFile,
+            ExtraData="\n(Please send email to %s for help, attaching following call stack trace!)\n" % MSG_EDKII_MAIL_ADDR,
+            RaiseError=False
+        )
         EdkLogger.quiet("(Python %s on %s) " % (platform.python_version(), sys.platform) + traceback.format_exc())
         return 1
 
     return 0
 
+
 if __name__ == '__main__':
     r = Main()
-    ## 0-127 is a safe return range, and 1 is a standard default error
-    if r < 0 or r > 127: r = 1
+    # 0-127 is a safe return range, and 1 is a standard default error
+    if r < 0 or r > 127:
+        r = 1
     sys.exit(r)
-

--- a/edk2basetools/Workspace/MetaFileParser.py
+++ b/edk2basetools/Workspace/MetaFileParser.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # This file is used to parse meta files
 #
 # Copyright (c) 2008 - 2018, Intel Corporation. All rights reserved.<BR>
@@ -32,12 +32,14 @@ from .MetaFileTable import MetaFileStorage
 from .MetaFileCommentParser import CheckInfComment
 from edk2basetools.Common.DataType import TAB_COMMENT_EDK_START, TAB_COMMENT_EDK_END
 
-## RegEx for finding file versions
+# RegEx for finding file versions
 hexVersionPattern = re.compile(r'0[xX][\da-f-A-F]{5,8}')
 decVersionPattern = re.compile(r'\d+\.\d+')
 CODEPattern = re.compile(r"{CODE\([a-fA-F0-9Xx\{\},\s]*\)}")
 
-## A decorator used to parse macro definition
+# A decorator used to parse macro definition
+
+
 def ParseMacro(Parser):
     def MacroParser(self):
         Match = GlobalData.gMacroDefPattern.match(self._CurrentLine)
@@ -103,7 +105,7 @@ def ParseMacro(Parser):
 
     return MacroParser
 
-## Base class of parser
+# Base class of parser
 #
 #  This class is used for derivation purpose. The specific parser for one kind
 # type file must derive this class and implement some public interfaces.
@@ -115,6 +117,8 @@ def ParseMacro(Parser):
 #   @param      Owner           Owner ID (for sub-section parsing)
 #   @param      From            ID from which the data comes (for !INCLUDE directive)
 #
+
+
 class MetaFileParser(object):
     # data type (file content) for specific file type
     DataType = {}
@@ -122,7 +126,7 @@ class MetaFileParser(object):
     # Parser objects used to implement singleton
     MetaFiles = {}
 
-    ## Factory method
+    # Factory method
     #
     # One file, one parser object. This factory method makes sure that there's
     # only one object constructed for one meta file.
@@ -141,7 +145,7 @@ class MetaFileParser(object):
             Class.MetaFiles[FilePath] = ParserObject
             return ParserObject
 
-    ## Constructor of MetaFileParser
+    # Constructor of MetaFileParser
     #
     #  Initialize object of MetaFileParser
     #
@@ -152,7 +156,7 @@ class MetaFileParser(object):
     #   @param      Owner           Owner ID (for sub-section parsing)
     #   @param      From            ID from which the data comes (for !INCLUDE directive)
     #
-    def __init__(self, FilePath, FileType, Arch, Table, Owner= -1, From= -1):
+    def __init__(self, FilePath, FileType, Arch, Table, Owner=-1, From=-1):
         self._Table = Table
         self._RawTable = Table
         self._Arch = Arch
@@ -191,19 +195,19 @@ class MetaFileParser(object):
         self._PcdDataTypeCODE = False
         self._CurrentPcdName = ""
 
-    ## Store the parsed data in table
+    # Store the parsed data in table
     def _Store(self, *Args):
         return self._Table.Insert(*Args)
 
-    ## Virtual method for starting parse
+    # Virtual method for starting parse
     def Start(self):
         raise NotImplementedError
 
-    ## Notify a post-process is needed
+    # Notify a post-process is needed
     def DoPostProcess(self):
         self._PostProcessed = False
 
-    ## Set parsing complete flag in both class and table
+    # Set parsing complete flag in both class and table
     def _Done(self):
         self._Finished = True
         self._Table.SetEndFlag()
@@ -211,17 +215,17 @@ class MetaFileParser(object):
     def _PostProcess(self):
         self._PostProcessed = True
 
-    ## Get the parse complete flag
+    # Get the parse complete flag
     @property
     def Finished(self):
         return self._Finished
 
-    ## Set the complete flag
+    # Set the complete flag
     @Finished.setter
     def Finished(self, Value):
         self._Finished = Value
 
-    ## Remove records that do not match given Filter Arch
+    # Remove records that do not match given Filter Arch
     def _FilterRecordList(self, RecordList, FilterArch):
         NewRecordList = []
         for Record in RecordList:
@@ -230,7 +234,7 @@ class MetaFileParser(object):
                 NewRecordList.append(Record)
         return NewRecordList
 
-    ## Use [] style to query data in table, just for readability
+    # Use [] style to query data in table, just for readability
     #
     #   DataInfo = [data_type, scope1(arch), scope2(platform/moduletype)]
     #
@@ -259,18 +263,19 @@ class MetaFileParser(object):
                 self._Table = self._RawTable
                 self._PostProcessed = False
                 self.Start()
-    ## Data parser for the common format in different type of file
+    # Data parser for the common format in different type of file
     #
     #   The common format in the meatfile is like
     #
     #       xxx1 | xxx2 | xxx3
     #
+
     @ParseMacro
     def _CommonParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_VALUE_SPLIT)
         self._ValueList[0:len(TokenList)] = TokenList
 
-    ## Data parser for the format in which there's path
+    # Data parser for the format in which there's path
     #
     #   Only path can have macro used. So we need to replace them before use.
     #
@@ -283,17 +288,17 @@ class MetaFileParser(object):
             Macros = self._Macros
             self._ValueList = [ReplaceMacro(Value, Macros) for Value in self._ValueList]
 
-    ## Skip unsupported data
+    # Skip unsupported data
     def _Skip(self):
         EdkLogger.warn("Parser", "Unrecognized content", File=self.MetaFile,
-                        Line=self._LineIndex + 1, ExtraData=self._CurrentLine);
+                       Line=self._LineIndex + 1, ExtraData=self._CurrentLine)
         self._ValueList[0:1] = [self._CurrentLine]
 
-    ## Skip unsupported data for UserExtension Section
+    # Skip unsupported data for UserExtension Section
     def _SkipUserExtension(self):
         self._ValueList[0:1] = [self._CurrentLine]
 
-    ## Section header parser
+    # Section header parser
     #
     #   The section header is always in following format:
     #
@@ -353,14 +358,14 @@ class MetaFileParser(object):
         # If the section information is needed later, it should be stored in database
         self._ValueList[0] = self._SectionName
 
-    ## [packages] section parser
+    # [packages] section parser
     @ParseMacro
     def _PackageParser(self):
         self._CurrentLine = CleanString(self._CurrentLine)
         self._Packages.append(self._CurrentLine)
         self._ValueList[0] = self._CurrentLine
 
-    ## [defines] section parser
+    # [defines] section parser
     @ParseMacro
     def _DefineParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_EQUAL_SPLIT, 1)
@@ -378,9 +383,11 @@ class MetaFileParser(object):
         if len(MacroUsed) != 0:
             for Macro in MacroUsed:
                 if Macro in GlobalData.gGlobalDefines:
-                    EdkLogger.error("Parser", FORMAT_INVALID, "Global macro %s is not permitted." % (Macro), ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
+                    EdkLogger.error("Parser", FORMAT_INVALID, "Global macro %s is not permitted." %
+                                    (Macro), ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
             else:
-                EdkLogger.error("Parser", FORMAT_INVALID, "%s not defined" % (Macro), ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
+                EdkLogger.error("Parser", FORMAT_INVALID, "%s not defined" %
+                                (Macro), ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
         # Sometimes, we need to make differences between EDK and EDK2 modules
         if Name == 'INF_VERSION':
             if hexVersionPattern.match(Value):
@@ -402,7 +409,7 @@ class MetaFileParser(object):
             self._FileLocalMacros[Name] = Value
         self._Defines[Name] = Value
 
-    ## [BuildOptions] section parser
+    # [BuildOptions] section parser
     @ParseMacro
     def _BuildOptionParser(self):
         self._CurrentLine = CleanString(self._CurrentLine, BuildOption=True)
@@ -413,7 +420,7 @@ class MetaFileParser(object):
             self._ValueList[1] = TokenList2[1]              # keys
         else:
             self._ValueList[1] = TokenList[0]
-        if len(TokenList) == 2 and not isinstance(self, DscParser): # value
+        if len(TokenList) == 2 and not isinstance(self, DscParser):  # value
             self._ValueList[2] = ReplaceMacro(TokenList[1], self._Macros)
 
         if self._ValueList[1].count('_') != 4:
@@ -424,7 +431,8 @@ class MetaFileParser(object):
                 ExtraData=self._CurrentLine,
                 File=self.MetaFile,
                 Line=self._LineIndex + 1
-                )
+            )
+
     def GetValidExpression(self, TokenSpaceGuid, PcdCName):
         return self._Table.GetValidExpression(TokenSpaceGuid, PcdCName)
 
@@ -435,7 +443,7 @@ class MetaFileParser(object):
         Macros.update(self._GetApplicableSectionMacro())
         return Macros
 
-    ## Construct section Macro dict
+    # Construct section Macro dict
     def _ConstructSectionMacroDict(self, Name, Value):
         ScopeKey = [(Scope[0], Scope[1], Scope[2]) for Scope in self._Scope]
         ScopeKey = tuple(ScopeKey)
@@ -450,8 +458,8 @@ class MetaFileParser(object):
 
         self._SectionsMacroDict[SectionDictKey][Name] = Value
 
-    ## Get section Macros that are applicable to current line, which may come from other sections
-    ## that share the same name while scope is wider
+    # Get section Macros that are applicable to current line, which may come from other sections
+    # that share the same name while scope is wider
     def _GetApplicableSectionMacro(self):
         Macros = {}
 
@@ -468,7 +476,7 @@ class MetaFileParser(object):
                 continue
 
             for ActiveScope in self._Scope:
-                Scope0, Scope1, Scope2= ActiveScope[0], ActiveScope[1], ActiveScope[2]
+                Scope0, Scope1, Scope2 = ActiveScope[0], ActiveScope[1], ActiveScope[2]
                 if(Scope0, Scope1, Scope2) not in Scope:
                     break
             else:
@@ -490,7 +498,7 @@ class MetaFileParser(object):
 
         return Macros
 
-    def ProcessMultipleLineCODEValue(self,Content):
+    def ProcessMultipleLineCODEValue(self, Content):
         CODEBegin = False
         CODELine = ""
         continuelinecount = 0
@@ -499,7 +507,7 @@ class MetaFileParser(object):
             Line = Content[Index]
             if CODEBegin:
                 CODELine = CODELine + Line
-                continuelinecount +=1
+                continuelinecount += 1
                 if ")}" in Line:
                     newContent.append(CODELine)
                     for _ in range(continuelinecount):
@@ -525,40 +533,42 @@ class MetaFileParser(object):
 
     _SectionParser = {}
 
-## INF file parser class
+# INF file parser class
 #
 #   @param      FilePath        The path of platform description file
 #   @param      FileType        The raw data of DSC file
 #   @param      Table           Database used to retrieve module/package information
 #   @param      Macros          Macros used for replacement in file
 #
+
+
 class InfParser(MetaFileParser):
     # INF file supported data types (one type per section)
     DataType = {
-        TAB_UNKNOWN.upper() : MODEL_UNKNOWN,
-        TAB_INF_DEFINES.upper() : MODEL_META_DATA_HEADER,
-        TAB_DSC_DEFINES_DEFINE : MODEL_META_DATA_DEFINE,
-        TAB_BUILD_OPTIONS.upper() : MODEL_META_DATA_BUILD_OPTION,
-        TAB_INCLUDES.upper() : MODEL_EFI_INCLUDE,
-        TAB_LIBRARIES.upper() : MODEL_EFI_LIBRARY_INSTANCE,
-        TAB_LIBRARY_CLASSES.upper() : MODEL_EFI_LIBRARY_CLASS,
-        TAB_PACKAGES.upper() : MODEL_META_DATA_PACKAGE,
-        TAB_NMAKE.upper() : MODEL_META_DATA_NMAKE,
-        TAB_INF_FIXED_PCD.upper() : MODEL_PCD_FIXED_AT_BUILD,
-        TAB_INF_PATCH_PCD.upper() : MODEL_PCD_PATCHABLE_IN_MODULE,
-        TAB_INF_FEATURE_PCD.upper() : MODEL_PCD_FEATURE_FLAG,
-        TAB_INF_PCD_EX.upper() : MODEL_PCD_DYNAMIC_EX,
-        TAB_INF_PCD.upper() : MODEL_PCD_DYNAMIC,
-        TAB_SOURCES.upper() : MODEL_EFI_SOURCE_FILE,
-        TAB_GUIDS.upper() : MODEL_EFI_GUID,
-        TAB_PROTOCOLS.upper() : MODEL_EFI_PROTOCOL,
-        TAB_PPIS.upper() : MODEL_EFI_PPI,
-        TAB_DEPEX.upper() : MODEL_EFI_DEPEX,
-        TAB_BINARIES.upper() : MODEL_EFI_BINARY_FILE,
-        TAB_USER_EXTENSIONS.upper() : MODEL_META_DATA_USER_EXTENSION
+        TAB_UNKNOWN.upper(): MODEL_UNKNOWN,
+        TAB_INF_DEFINES.upper(): MODEL_META_DATA_HEADER,
+        TAB_DSC_DEFINES_DEFINE: MODEL_META_DATA_DEFINE,
+        TAB_BUILD_OPTIONS.upper(): MODEL_META_DATA_BUILD_OPTION,
+        TAB_INCLUDES.upper(): MODEL_EFI_INCLUDE,
+        TAB_LIBRARIES.upper(): MODEL_EFI_LIBRARY_INSTANCE,
+        TAB_LIBRARY_CLASSES.upper(): MODEL_EFI_LIBRARY_CLASS,
+        TAB_PACKAGES.upper(): MODEL_META_DATA_PACKAGE,
+        TAB_NMAKE.upper(): MODEL_META_DATA_NMAKE,
+        TAB_INF_FIXED_PCD.upper(): MODEL_PCD_FIXED_AT_BUILD,
+        TAB_INF_PATCH_PCD.upper(): MODEL_PCD_PATCHABLE_IN_MODULE,
+        TAB_INF_FEATURE_PCD.upper(): MODEL_PCD_FEATURE_FLAG,
+        TAB_INF_PCD_EX.upper(): MODEL_PCD_DYNAMIC_EX,
+        TAB_INF_PCD.upper(): MODEL_PCD_DYNAMIC,
+        TAB_SOURCES.upper(): MODEL_EFI_SOURCE_FILE,
+        TAB_GUIDS.upper(): MODEL_EFI_GUID,
+        TAB_PROTOCOLS.upper(): MODEL_EFI_PROTOCOL,
+        TAB_PPIS.upper(): MODEL_EFI_PPI,
+        TAB_DEPEX.upper(): MODEL_EFI_DEPEX,
+        TAB_BINARIES.upper(): MODEL_EFI_BINARY_FILE,
+        TAB_USER_EXTENSIONS.upper(): MODEL_META_DATA_USER_EXTENSION
     }
 
-    ## Constructor of InfParser
+    # Constructor of InfParser
     #
     #  Initialize object of InfParser
     #
@@ -574,7 +584,7 @@ class InfParser(MetaFileParser):
         MetaFileParser.__init__(self, FilePath, FileType, Arch, Table)
         self.PcdsDict = {}
 
-    ## Parser starter
+    # Parser starter
     def Start(self):
         NmakeLine = ''
         Content = ''
@@ -648,7 +658,8 @@ class InfParser(MetaFileParser):
                                            MODEL_EFI_LIBRARY_INSTANCE,
                                            MODEL_META_DATA_NMAKE]:
                     EdkLogger.error('Parser', FORMAT_INVALID,
-                                    "Section [%s] is not allowed in inf file with version 0x%08x" % (self._SectionName, self._Version),
+                                    "Section [%s] is not allowed in inf file with version 0x%08x" % (
+                                        self._SectionName, self._Version),
                                     ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
                 continue
             # merge two lines specified by '\' in section NMAKE
@@ -678,7 +689,7 @@ class InfParser(MetaFileParser):
                 continue
             if Comment:
                 Comments.append((Comment, Index + 1))
-            if GlobalData.gOptions and GlobalData.gOptions.CheckUsage:
+            if GlobalData.gArguments and GlobalData.gArguments.CheckUsage:
                 CheckInfComment(self._SectionType, Comments, str(self.MetaFile), Index + 1, self._ValueList)
             #
             # Model, Value1, Value2, Value3, Arch, Platform, BelongsToItem=-1,
@@ -686,18 +697,18 @@ class InfParser(MetaFileParser):
             #
             for Arch, Platform, _ in self._Scope:
                 LastItem = self._Store(self._SectionType,
-                            self._ValueList[0],
-                            self._ValueList[1],
-                            self._ValueList[2],
-                            Arch,
-                            Platform,
-                            self._Owner[-1],
-                            self._LineIndex + 1,
-                            - 1,
-                            self._LineIndex + 1,
-                            - 1,
-                            0
-                            )
+                                       self._ValueList[0],
+                                       self._ValueList[1],
+                                       self._ValueList[2],
+                                       Arch,
+                                       Platform,
+                                       self._Owner[-1],
+                                       self._LineIndex + 1,
+                                       - 1,
+                                       self._LineIndex + 1,
+                                       - 1,
+                                       0
+                                       )
                 for Comment, LineNo in Comments:
                     self._Store(MODEL_META_DATA_COMMENT, Comment, '', '', Arch, Platform,
                                 LastItem, LineNo, -1, LineNo, -1, 0)
@@ -711,10 +722,10 @@ class InfParser(MetaFileParser):
         # If there are tail comments in INF file, save to database whatever the comments are
         for Comment in TailComments:
             self._Store(MODEL_META_DATA_TAIL_COMMENT, Comment[0], '', '', TAB_COMMON,
-                                TAB_COMMON, self._Owner[-1], -1, -1, -1, -1, 0)
+                        TAB_COMMON, self._Owner[-1], -1, -1, -1, -1, 0)
         self._Done()
 
-    ## Data parser for the format in which there's path
+    # Data parser for the format in which there's path
     #
     #   Only path can have macro used. So we need to replace them before use.
     #
@@ -729,7 +740,7 @@ class InfParser(MetaFileParser):
                     continue
                 self._ValueList[Index] = ReplaceMacro(Value, Macros)
 
-    ## Parse [Sources] section
+    # Parse [Sources] section
     #
     #   Only path can have macro used. So we need to replace them before use.
     #
@@ -750,7 +761,7 @@ class InfParser(MetaFileParser):
             pass
         self._ValueList = [ReplaceMacro(Value, Macros) for Value in self._ValueList]
 
-    ## Parse [Binaries] section
+    # Parse [Binaries] section
     #
     #   Only path can have macro used. So we need to replace them before use.
     #
@@ -772,7 +783,7 @@ class InfParser(MetaFileParser):
         self._ValueList[0:len(TokenList)] = TokenList
         self._ValueList[1] = ReplaceMacro(self._ValueList[1], self._Macros)
 
-    ## [nmake] section parser (Edk.x style only)
+    # [nmake] section parser (Edk.x style only)
     def _NmakeParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_EQUAL_SPLIT, 1)
         self._ValueList[0:len(TokenList)] = TokenList
@@ -781,7 +792,7 @@ class InfParser(MetaFileParser):
         # remove self-reference in macro setting
         #self._ValueList[1] = ReplaceMacro(self._ValueList[1], {self._ValueList[0]:''})
 
-    ## [FixedPcd], [FeaturePcd], [PatchPcd], [Pcd] and [PcdEx] sections parser
+    # [FixedPcd], [FeaturePcd], [PatchPcd], [Pcd] and [PcdEx] sections parser
     @ParseMacro
     def _PcdParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_VALUE_SPLIT, 1)
@@ -806,7 +817,7 @@ class InfParser(MetaFileParser):
             elif InfPcdValueList[0] in ['False', 'false', 'FALSE']:
                 self._ValueList[2] = TokenList[1].replace(InfPcdValueList[0], '0', 1)
             elif isinstance(InfPcdValueList[0], str) and InfPcdValueList[0].find('$(') >= 0:
-                Value = ReplaceExprMacro(InfPcdValueList[0],self._Macros)
+                Value = ReplaceExprMacro(InfPcdValueList[0], self._Macros)
                 if Value != '0':
                     self._ValueList[2] = Value
         if (self._ValueList[0], self._ValueList[1]) not in self.PcdsDict:
@@ -816,35 +827,35 @@ class InfParser(MetaFileParser):
                             ExtraData=self._CurrentLine + " (<TokenSpaceGuidCName>.<PcdCName>)",
                             File=self.MetaFile, Line=self._LineIndex + 1)
 
-    ## [depex] section parser
+    # [depex] section parser
     @ParseMacro
     def _DepexParser(self):
         self._ValueList[0:1] = [self._CurrentLine]
 
     _SectionParser = {
-        MODEL_UNKNOWN                   :   MetaFileParser._Skip,
-        MODEL_META_DATA_HEADER          :   MetaFileParser._DefineParser,
-        MODEL_META_DATA_BUILD_OPTION    :   MetaFileParser._BuildOptionParser,
-        MODEL_EFI_INCLUDE               :   _IncludeParser, # for Edk.x modules
-        MODEL_EFI_LIBRARY_INSTANCE      :   MetaFileParser._CommonParser, # for Edk.x modules
-        MODEL_EFI_LIBRARY_CLASS         :   MetaFileParser._PathParser,
-        MODEL_META_DATA_PACKAGE         :   MetaFileParser._PathParser,
-        MODEL_META_DATA_NMAKE           :   _NmakeParser, # for Edk.x modules
-        MODEL_PCD_FIXED_AT_BUILD        :   _PcdParser,
-        MODEL_PCD_PATCHABLE_IN_MODULE   :   _PcdParser,
-        MODEL_PCD_FEATURE_FLAG          :   _PcdParser,
-        MODEL_PCD_DYNAMIC_EX            :   _PcdParser,
-        MODEL_PCD_DYNAMIC               :   _PcdParser,
-        MODEL_EFI_SOURCE_FILE           :   _SourceFileParser,
-        MODEL_EFI_GUID                  :   MetaFileParser._CommonParser,
-        MODEL_EFI_PROTOCOL              :   MetaFileParser._CommonParser,
-        MODEL_EFI_PPI                   :   MetaFileParser._CommonParser,
-        MODEL_EFI_DEPEX                 :   _DepexParser,
-        MODEL_EFI_BINARY_FILE           :   _BinaryFileParser,
-        MODEL_META_DATA_USER_EXTENSION  :   MetaFileParser._SkipUserExtension,
+        MODEL_UNKNOWN: MetaFileParser._Skip,
+        MODEL_META_DATA_HEADER: MetaFileParser._DefineParser,
+        MODEL_META_DATA_BUILD_OPTION: MetaFileParser._BuildOptionParser,
+        MODEL_EFI_INCLUDE: _IncludeParser,  # for Edk.x modules
+        MODEL_EFI_LIBRARY_INSTANCE: MetaFileParser._CommonParser,  # for Edk.x modules
+        MODEL_EFI_LIBRARY_CLASS: MetaFileParser._PathParser,
+        MODEL_META_DATA_PACKAGE: MetaFileParser._PathParser,
+        MODEL_META_DATA_NMAKE: _NmakeParser,  # for Edk.x modules
+        MODEL_PCD_FIXED_AT_BUILD: _PcdParser,
+        MODEL_PCD_PATCHABLE_IN_MODULE: _PcdParser,
+        MODEL_PCD_FEATURE_FLAG: _PcdParser,
+        MODEL_PCD_DYNAMIC_EX: _PcdParser,
+        MODEL_PCD_DYNAMIC: _PcdParser,
+        MODEL_EFI_SOURCE_FILE: _SourceFileParser,
+        MODEL_EFI_GUID: MetaFileParser._CommonParser,
+        MODEL_EFI_PROTOCOL: MetaFileParser._CommonParser,
+        MODEL_EFI_PPI: MetaFileParser._CommonParser,
+        MODEL_EFI_DEPEX: _DepexParser,
+        MODEL_EFI_BINARY_FILE: _BinaryFileParser,
+        MODEL_META_DATA_USER_EXTENSION: MetaFileParser._SkipUserExtension,
     }
 
-## DSC file parser class
+# DSC file parser class
 #
 #   @param      FilePath        The path of platform description file
 #   @param      FileType        The raw data of DSC file
@@ -853,37 +864,39 @@ class InfParser(MetaFileParser):
 #   @param      Owner           Owner ID (for sub-section parsing)
 #   @param      From            ID from which the data comes (for !INCLUDE directive)
 #
+
+
 class DscParser(MetaFileParser):
     # DSC file supported data types (one type per section)
     DataType = {
-        TAB_SKUIDS.upper()                          :   MODEL_EFI_SKU_ID,
-        TAB_DEFAULT_STORES.upper()                  :   MODEL_EFI_DEFAULT_STORES,
-        TAB_LIBRARIES.upper()                       :   MODEL_EFI_LIBRARY_INSTANCE,
-        TAB_LIBRARY_CLASSES.upper()                 :   MODEL_EFI_LIBRARY_CLASS,
-        TAB_BUILD_OPTIONS.upper()                   :   MODEL_META_DATA_BUILD_OPTION,
-        TAB_PACKAGES.upper()                        :   MODEL_META_DATA_PACKAGE,
-        TAB_PCDS_FIXED_AT_BUILD_NULL.upper()        :   MODEL_PCD_FIXED_AT_BUILD,
-        TAB_PCDS_PATCHABLE_IN_MODULE_NULL.upper()   :   MODEL_PCD_PATCHABLE_IN_MODULE,
-        TAB_PCDS_FEATURE_FLAG_NULL.upper()          :   MODEL_PCD_FEATURE_FLAG,
-        TAB_PCDS_DYNAMIC_DEFAULT_NULL.upper()       :   MODEL_PCD_DYNAMIC_DEFAULT,
-        TAB_PCDS_DYNAMIC_HII_NULL.upper()           :   MODEL_PCD_DYNAMIC_HII,
-        TAB_PCDS_DYNAMIC_VPD_NULL.upper()           :   MODEL_PCD_DYNAMIC_VPD,
-        TAB_PCDS_DYNAMIC_EX_DEFAULT_NULL.upper()    :   MODEL_PCD_DYNAMIC_EX_DEFAULT,
-        TAB_PCDS_DYNAMIC_EX_HII_NULL.upper()        :   MODEL_PCD_DYNAMIC_EX_HII,
-        TAB_PCDS_DYNAMIC_EX_VPD_NULL.upper()        :   MODEL_PCD_DYNAMIC_EX_VPD,
-        TAB_COMPONENTS.upper()                      :   MODEL_META_DATA_COMPONENT,
-        TAB_DSC_DEFINES.upper()                     :   MODEL_META_DATA_HEADER,
-        TAB_DSC_DEFINES_DEFINE                      :   MODEL_META_DATA_DEFINE,
-        TAB_DSC_DEFINES_EDKGLOBAL                   :   MODEL_META_DATA_GLOBAL_DEFINE,
-        TAB_INCLUDE.upper()                         :   MODEL_META_DATA_INCLUDE,
-        TAB_IF.upper()                              :   MODEL_META_DATA_CONDITIONAL_STATEMENT_IF,
-        TAB_IF_DEF.upper()                          :   MODEL_META_DATA_CONDITIONAL_STATEMENT_IFDEF,
-        TAB_IF_N_DEF.upper()                        :   MODEL_META_DATA_CONDITIONAL_STATEMENT_IFNDEF,
-        TAB_ELSE_IF.upper()                         :   MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSEIF,
-        TAB_ELSE.upper()                            :   MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSE,
-        TAB_END_IF.upper()                          :   MODEL_META_DATA_CONDITIONAL_STATEMENT_ENDIF,
-        TAB_USER_EXTENSIONS.upper()                 :   MODEL_META_DATA_USER_EXTENSION,
-        TAB_ERROR.upper()                           :   MODEL_META_DATA_CONDITIONAL_STATEMENT_ERROR,
+        TAB_SKUIDS.upper(): MODEL_EFI_SKU_ID,
+        TAB_DEFAULT_STORES.upper(): MODEL_EFI_DEFAULT_STORES,
+        TAB_LIBRARIES.upper(): MODEL_EFI_LIBRARY_INSTANCE,
+        TAB_LIBRARY_CLASSES.upper(): MODEL_EFI_LIBRARY_CLASS,
+        TAB_BUILD_OPTIONS.upper(): MODEL_META_DATA_BUILD_OPTION,
+        TAB_PACKAGES.upper(): MODEL_META_DATA_PACKAGE,
+        TAB_PCDS_FIXED_AT_BUILD_NULL.upper(): MODEL_PCD_FIXED_AT_BUILD,
+        TAB_PCDS_PATCHABLE_IN_MODULE_NULL.upper(): MODEL_PCD_PATCHABLE_IN_MODULE,
+        TAB_PCDS_FEATURE_FLAG_NULL.upper(): MODEL_PCD_FEATURE_FLAG,
+        TAB_PCDS_DYNAMIC_DEFAULT_NULL.upper(): MODEL_PCD_DYNAMIC_DEFAULT,
+        TAB_PCDS_DYNAMIC_HII_NULL.upper(): MODEL_PCD_DYNAMIC_HII,
+        TAB_PCDS_DYNAMIC_VPD_NULL.upper(): MODEL_PCD_DYNAMIC_VPD,
+        TAB_PCDS_DYNAMIC_EX_DEFAULT_NULL.upper(): MODEL_PCD_DYNAMIC_EX_DEFAULT,
+        TAB_PCDS_DYNAMIC_EX_HII_NULL.upper(): MODEL_PCD_DYNAMIC_EX_HII,
+        TAB_PCDS_DYNAMIC_EX_VPD_NULL.upper(): MODEL_PCD_DYNAMIC_EX_VPD,
+        TAB_COMPONENTS.upper(): MODEL_META_DATA_COMPONENT,
+        TAB_DSC_DEFINES.upper(): MODEL_META_DATA_HEADER,
+        TAB_DSC_DEFINES_DEFINE: MODEL_META_DATA_DEFINE,
+        TAB_DSC_DEFINES_EDKGLOBAL: MODEL_META_DATA_GLOBAL_DEFINE,
+        TAB_INCLUDE.upper(): MODEL_META_DATA_INCLUDE,
+        TAB_IF.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_IF,
+        TAB_IF_DEF.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_IFDEF,
+        TAB_IF_N_DEF.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_IFNDEF,
+        TAB_ELSE_IF.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSEIF,
+        TAB_ELSE.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSE,
+        TAB_END_IF.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_ENDIF,
+        TAB_USER_EXTENSIONS.upper(): MODEL_META_DATA_USER_EXTENSION,
+        TAB_ERROR.upper(): MODEL_META_DATA_CONDITIONAL_STATEMENT_ERROR,
     }
 
     # Valid names in define section
@@ -917,7 +930,7 @@ class DscParser(MetaFileParser):
 
     IncludedFiles = set()
 
-    ## Constructor of DscParser
+    # Constructor of DscParser
     #
     #  Initialize object of DscParser
     #
@@ -928,7 +941,7 @@ class DscParser(MetaFileParser):
     #   @param      Owner           Owner ID (for sub-section parsing)
     #   @param      From            ID from which the data comes (for !INCLUDE directive)
     #
-    def __init__(self, FilePath, FileType, Arch, Table, Owner= -1, From= -1):
+    def __init__(self, FilePath, FileType, Arch, Table, Owner=-1, From=-1):
         # prevent re-initialization
         if hasattr(self, "_Table") and self._Table is Table:
             return
@@ -950,11 +963,11 @@ class DscParser(MetaFileParser):
         #  Map the ID between the original table and new table to track
         #  the owner item
         #
-        self._IdMapping = {-1:-1}
+        self._IdMapping = {-1: -1}
 
         self._Content = None
 
-    ## Parser starter
+    # Parser starter
     def Start(self):
         Content = ''
         try:
@@ -1004,7 +1017,8 @@ class DscParser(MetaFileParser):
                     self._DirectiveParser()
                 continue
             if Line[0] == TAB_OPTION_START and not self._InSubsection:
-                EdkLogger.error("Parser", FILE_READ_FAILURE, "Missing the '{' before %s in Line %s" % (Line, Index+1), ExtraData=self.MetaFile)
+                EdkLogger.error("Parser", FILE_READ_FAILURE, "Missing the '{' before %s in Line %s" % (
+                    Line, Index + 1), ExtraData=self.MetaFile)
 
             if self._InSubsection:
                 SectionType = self._SubsectionType
@@ -1030,21 +1044,21 @@ class DscParser(MetaFileParser):
                 if self._SubsectionType != MODEL_UNKNOWN and Arch in OwnerId:
                     Owner = OwnerId[Arch]
                 self._LastItem = self._Store(
-                                        self._ItemType,
-                                        self._ValueList[0],
-                                        self._ValueList[1],
-                                        self._ValueList[2],
-                                        Arch,
-                                        ModuleType,
-                                        DefaultStore,
-                                        Owner,
-                                        self._From,
-                                        self._LineIndex + 1,
-                                        - 1,
-                                        self._LineIndex + 1,
-                                        - 1,
-                                        self._Enabled
-                                        )
+                    self._ItemType,
+                    self._ValueList[0],
+                    self._ValueList[1],
+                    self._ValueList[2],
+                    Arch,
+                    ModuleType,
+                    DefaultStore,
+                    Owner,
+                    self._From,
+                    self._LineIndex + 1,
+                    - 1,
+                    self._LineIndex + 1,
+                    - 1,
+                    self._Enabled
+                )
                 if self._SubsectionType == MODEL_UNKNOWN and self._InSubsection:
                     OwnerId[Arch] = self._LastItem
 
@@ -1054,7 +1068,7 @@ class DscParser(MetaFileParser):
                             ExtraData=Text, File=self.MetaFile, Line=Line)
         self._Done()
 
-    ## <subsection_header> parser
+    # <subsection_header> parser
     def _SubsectionHeaderParser(self):
         self._SubsectionName = self._CurrentLine[1:-1].upper()
         if self._SubsectionName in self.DataType:
@@ -1065,7 +1079,7 @@ class DscParser(MetaFileParser):
                            Line=self._LineIndex + 1, ExtraData=self._CurrentLine)
         self._ValueList[0] = self._SubsectionName
 
-    ## Directive statement parser
+    # Directive statement parser
     def _DirectiveParser(self):
         self._ValueList = ['', '', '']
         TokenList = GetSplitValueList(self._CurrentLine, ' ', 1)
@@ -1123,23 +1137,23 @@ class DscParser(MetaFileParser):
         #
         for Arch, ModuleType, DefaultStore in Scope:
             self._LastItem = self._Store(
-                                    ItemType,
-                                    self._ValueList[0],
-                                    self._ValueList[1],
-                                    self._ValueList[2],
-                                    Arch,
-                                    ModuleType,
-                                    DefaultStore,
-                                    self._Owner[-1],
-                                    self._From,
-                                    self._LineIndex + 1,
-                                    - 1,
-                                    self._LineIndex + 1,
-                                    - 1,
-                                    0
-                                    )
+                ItemType,
+                self._ValueList[0],
+                self._ValueList[1],
+                self._ValueList[2],
+                Arch,
+                ModuleType,
+                DefaultStore,
+                self._Owner[-1],
+                self._From,
+                self._LineIndex + 1,
+                - 1,
+                self._LineIndex + 1,
+                - 1,
+                0
+            )
 
-    ## [defines] section parser
+    # [defines] section parser
     @ParseMacro
     def _DefineParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_EQUAL_SPLIT, 1)
@@ -1153,7 +1167,7 @@ class DscParser(MetaFileParser):
             EdkLogger.error('Parser', FORMAT_INVALID, "No value specified",
                             ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
         if (not self._ValueList[1] in self.DefineKeywords and
-            (self._InSubsection and self._ValueList[1] not in self.SubSectionDefineKeywords)):
+                (self._InSubsection and self._ValueList[1] not in self.SubSectionDefineKeywords)):
             EdkLogger.error('Parser', FORMAT_INVALID,
                             "Unknown keyword found: %s. "
                             "If this is a macro you must "
@@ -1170,6 +1184,7 @@ class DscParser(MetaFileParser):
             EdkLogger.error('Parser', FORMAT_INVALID, "Correct format is '<Number>|<UiName>[|<UiName>]'",
                             ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
         self._ValueList[0:len(TokenList)] = TokenList
+
     @ParseMacro
     def _DefaultStoresParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_VALUE_SPLIT)
@@ -1178,15 +1193,14 @@ class DscParser(MetaFileParser):
                             ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
         self._ValueList[0:len(TokenList)] = TokenList
 
-    ## Parse Edk style of library modules
+    # Parse Edk style of library modules
     @ParseMacro
     def _LibraryInstanceParser(self):
         self._ValueList[0] = self._CurrentLine
 
-
     def _DecodeCODEData(self):
         pass
-    ## PCD sections parser
+    # PCD sections parser
     #
     #   [PcdsFixedAtBuild]
     #   [PcdsPatchableInModule]
@@ -1200,6 +1214,7 @@ class DscParser(MetaFileParser):
     #   [PcdsDynamicVpd]
     #   [PcdsDynamicHii]
     #
+
     @ParseMacro
     def _PcdParser(self):
         if self._PcdDataTypeCODE:
@@ -1231,7 +1246,8 @@ class DscParser(MetaFileParser):
         elif len(PcdNameTockens) == 3:
             self._ValueList[0], self._ValueList[1] = ".".join((PcdNameTockens[0], PcdNameTockens[1])), PcdNameTockens[2]
         elif len(PcdNameTockens) > 3:
-            self._ValueList[0], self._ValueList[1] = ".".join((PcdNameTockens[0], PcdNameTockens[1])), ".".join(PcdNameTockens[2:])
+            self._ValueList[0], self._ValueList[1] = ".".join(
+                (PcdNameTockens[0], PcdNameTockens[1])), ".".join(PcdNameTockens[2:])
         if len(TokenList) == 2:
             self._ValueList[2] = TokenList[1]
         if self._ValueList[0] == '' or self._ValueList[1] == '':
@@ -1251,7 +1267,7 @@ class DscParser(MetaFileParser):
         # Validate the datum type of Dynamic Defaul PCD and DynamicEx Default PCD
         ValueList = GetSplitValueList(self._ValueList[2])
         if len(ValueList) > 1 and ValueList[1] in [TAB_UINT8, TAB_UINT16, TAB_UINT32, TAB_UINT64] \
-                              and self._ItemType in [MODEL_PCD_DYNAMIC_DEFAULT, MODEL_PCD_DYNAMIC_EX_DEFAULT]:
+                and self._ItemType in [MODEL_PCD_DYNAMIC_DEFAULT, MODEL_PCD_DYNAMIC_EX_DEFAULT]:
             EdkLogger.error('Parser', FORMAT_INVALID, "The datum type '%s' of PCD is wrong" % ValueList[1],
                             ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
 
@@ -1260,17 +1276,17 @@ class DscParser(MetaFileParser):
             DscPcdValueList = GetSplitValueList(TokenList[1], TAB_VALUE_SPLIT, 1)
             if len(DscPcdValueList[0].replace('L', '').replace('"', '').strip()) == 0:
                 EdkLogger.error('Parser', FORMAT_INVALID, "The VariableName field in the HII format PCD entry must not be an empty string",
-                            ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
+                                ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
 
         # if value are 'True', 'true', 'TRUE' or 'False', 'false', 'FALSE', replace with integer 1 or 0.
         DscPcdValueList = GetSplitValueList(TokenList[1], TAB_VALUE_SPLIT, 1)
         if DscPcdValueList[0] in ['True', 'true', 'TRUE']:
-            self._ValueList[2] = TokenList[1].replace(DscPcdValueList[0], '1', 1);
+            self._ValueList[2] = TokenList[1].replace(DscPcdValueList[0], '1', 1)
         elif DscPcdValueList[0] in ['False', 'false', 'FALSE']:
-            self._ValueList[2] = TokenList[1].replace(DscPcdValueList[0], '0', 1);
+            self._ValueList[2] = TokenList[1].replace(DscPcdValueList[0], '0', 1)
 
+    # [components] section parser
 
-    ## [components] section parser
     @ParseMacro
     def _ComponentParser(self):
         if self._CurrentLine[-1] == '{':
@@ -1280,7 +1296,7 @@ class DscParser(MetaFileParser):
         else:
             self._ValueList[0] = self._CurrentLine
 
-    ## [LibraryClasses] section
+    # [LibraryClasses] section
     @ParseMacro
     def _LibraryClassParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_VALUE_SPLIT)
@@ -1299,8 +1315,8 @@ class DscParser(MetaFileParser):
 
         self._ValueList[0:len(TokenList)] = TokenList
 
+    # [BuildOptions] section parser
 
-    ## [BuildOptions] section parser
     @ParseMacro
     def _BuildOptionParser(self):
         self._CurrentLine = CleanString(self._CurrentLine, BuildOption=True)
@@ -1322,9 +1338,9 @@ class DscParser(MetaFileParser):
                 ExtraData=self._CurrentLine,
                 File=self.MetaFile,
                 Line=self._LineIndex + 1
-                )
+            )
 
-    ## Override parent's method since we'll do all macro replacements in parser
+    # Override parent's method since we'll do all macro replacements in parser
     @property
     def _Macros(self):
         Macros = {}
@@ -1347,37 +1363,37 @@ class DscParser(MetaFileParser):
 
     def _PostProcess(self):
         Processer = {
-            MODEL_META_DATA_SECTION_HEADER                  :   self.__ProcessSectionHeader,
-            MODEL_META_DATA_SUBSECTION_HEADER               :   self.__ProcessSubsectionHeader,
-            MODEL_META_DATA_HEADER                          :   self.__ProcessDefine,
-            MODEL_META_DATA_DEFINE                          :   self.__ProcessDefine,
-            MODEL_META_DATA_GLOBAL_DEFINE                   :   self.__ProcessDefine,
-            MODEL_META_DATA_INCLUDE                         :   self.__ProcessDirective,
-            MODEL_META_DATA_PACKAGE                         :   self.__ProcessPackages,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_IF        :   self.__ProcessDirective,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSE      :   self.__ProcessDirective,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_IFDEF     :   self.__ProcessDirective,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_IFNDEF    :   self.__ProcessDirective,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_ENDIF     :   self.__ProcessDirective,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSEIF    :   self.__ProcessDirective,
-            MODEL_EFI_SKU_ID                                :   self.__ProcessSkuId,
-            MODEL_EFI_DEFAULT_STORES                        :   self.__ProcessDefaultStores,
-            MODEL_EFI_LIBRARY_INSTANCE                      :   self.__ProcessLibraryInstance,
-            MODEL_EFI_LIBRARY_CLASS                         :   self.__ProcessLibraryClass,
-            MODEL_PCD_FIXED_AT_BUILD                        :   self.__ProcessPcd,
-            MODEL_PCD_PATCHABLE_IN_MODULE                   :   self.__ProcessPcd,
-            MODEL_PCD_FEATURE_FLAG                          :   self.__ProcessPcd,
-            MODEL_PCD_DYNAMIC_DEFAULT                       :   self.__ProcessPcd,
-            MODEL_PCD_DYNAMIC_HII                           :   self.__ProcessPcd,
-            MODEL_PCD_DYNAMIC_VPD                           :   self.__ProcessPcd,
-            MODEL_PCD_DYNAMIC_EX_DEFAULT                    :   self.__ProcessPcd,
-            MODEL_PCD_DYNAMIC_EX_HII                        :   self.__ProcessPcd,
-            MODEL_PCD_DYNAMIC_EX_VPD                        :   self.__ProcessPcd,
-            MODEL_META_DATA_COMPONENT                       :   self.__ProcessComponent,
-            MODEL_META_DATA_BUILD_OPTION                    :   self.__ProcessBuildOption,
-            MODEL_UNKNOWN                                   :   self._Skip,
-            MODEL_META_DATA_USER_EXTENSION                  :   self._SkipUserExtension,
-            MODEL_META_DATA_CONDITIONAL_STATEMENT_ERROR     :   self._ProcessError,
+            MODEL_META_DATA_SECTION_HEADER: self.__ProcessSectionHeader,
+            MODEL_META_DATA_SUBSECTION_HEADER: self.__ProcessSubsectionHeader,
+            MODEL_META_DATA_HEADER: self.__ProcessDefine,
+            MODEL_META_DATA_DEFINE: self.__ProcessDefine,
+            MODEL_META_DATA_GLOBAL_DEFINE: self.__ProcessDefine,
+            MODEL_META_DATA_INCLUDE: self.__ProcessDirective,
+            MODEL_META_DATA_PACKAGE: self.__ProcessPackages,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_IF: self.__ProcessDirective,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSE: self.__ProcessDirective,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_IFDEF: self.__ProcessDirective,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_IFNDEF: self.__ProcessDirective,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_ENDIF: self.__ProcessDirective,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_ELSEIF: self.__ProcessDirective,
+            MODEL_EFI_SKU_ID: self.__ProcessSkuId,
+            MODEL_EFI_DEFAULT_STORES: self.__ProcessDefaultStores,
+            MODEL_EFI_LIBRARY_INSTANCE: self.__ProcessLibraryInstance,
+            MODEL_EFI_LIBRARY_CLASS: self.__ProcessLibraryClass,
+            MODEL_PCD_FIXED_AT_BUILD: self.__ProcessPcd,
+            MODEL_PCD_PATCHABLE_IN_MODULE: self.__ProcessPcd,
+            MODEL_PCD_FEATURE_FLAG: self.__ProcessPcd,
+            MODEL_PCD_DYNAMIC_DEFAULT: self.__ProcessPcd,
+            MODEL_PCD_DYNAMIC_HII: self.__ProcessPcd,
+            MODEL_PCD_DYNAMIC_VPD: self.__ProcessPcd,
+            MODEL_PCD_DYNAMIC_EX_DEFAULT: self.__ProcessPcd,
+            MODEL_PCD_DYNAMIC_EX_HII: self.__ProcessPcd,
+            MODEL_PCD_DYNAMIC_EX_VPD: self.__ProcessPcd,
+            MODEL_META_DATA_COMPONENT: self.__ProcessComponent,
+            MODEL_META_DATA_BUILD_OPTION: self.__ProcessBuildOption,
+            MODEL_UNKNOWN: self._Skip,
+            MODEL_META_DATA_USER_EXTENSION: self._SkipUserExtension,
+            MODEL_META_DATA_CONDITIONAL_STATEMENT_ERROR: self._ProcessError,
         }
 
         self._Table = MetaFileStorage(self._RawTable.DB, self.MetaFile, MODEL_FILE_DSC, True)
@@ -1393,7 +1409,7 @@ class DscParser(MetaFileParser):
         self._Content = self._RawTable.GetAll()
         self._ContentIndex = 0
         self._InSubsection = False
-        while self._ContentIndex < len(self._Content) :
+        while self._ContentIndex < len(self._Content):
             Id, self._ItemType, V1, V2, V3, S1, S2, S3, Owner, self._From, \
                 LineStart, ColStart, LineEnd, ColEnd, Enabled = self._Content[self._ContentIndex]
 
@@ -1439,12 +1455,12 @@ class DscParser(MetaFileParser):
                                         " it must be defined in a [PcdsFixedAtBuild] or [PcdsFeatureFlag] section"
                                         " of the DSC file, and it is currently defined in this section:"
                                         " %s, line #: %d." % (Excpt.Pcd, Info[0], Info[1]),
-                                    File=self._FileWithError, ExtraData=' '.join(self._ValueList),
-                                    Line=self._LineIndex + 1)
+                                        File=self._FileWithError, ExtraData=' '.join(self._ValueList),
+                                        Line=self._LineIndex + 1)
                     else:
                         EdkLogger.error('Parser', FORMAT_INVALID, "PCD (%s) is not defined in DSC file" % Excpt.Pcd,
-                                    File=self._FileWithError, ExtraData=' '.join(self._ValueList),
-                                    Line=self._LineIndex + 1)
+                                        File=self._FileWithError, ExtraData=' '.join(self._ValueList),
+                                        Line=self._LineIndex + 1)
                 else:
                     EdkLogger.error('Parser', FORMAT_INVALID, "Invalid expression: %s" % str(Excpt),
                                     File=self._FileWithError, ExtraData=' '.join(self._ValueList),
@@ -1460,26 +1476,27 @@ class DscParser(MetaFileParser):
             NewOwner = self._IdMapping.get(Owner, -1)
             self._Enabled = int((not self._DirectiveEvalStack) or (False not in self._DirectiveEvalStack))
             self._LastItem = self._Store(
-                                self._ItemType,
-                                self._ValueList[0],
-                                self._ValueList[1],
-                                self._ValueList[2],
-                                S1,
-                                S2,
-                                S3,
-                                NewOwner,
-                                self._From,
-                                self._LineIndex + 1,
-                                - 1,
-                                self._LineIndex + 1,
-                                - 1,
-                                self._Enabled
-                                )
+                self._ItemType,
+                self._ValueList[0],
+                self._ValueList[1],
+                self._ValueList[2],
+                S1,
+                S2,
+                S3,
+                NewOwner,
+                self._From,
+                self._LineIndex + 1,
+                - 1,
+                self._LineIndex + 1,
+                - 1,
+                self._Enabled
+            )
             self._IdMapping[Id] = self._LastItem
 
         GlobalData.gPlatformDefines.update(self._FileLocalMacros)
         self._PostProcessed = True
         self._Content = None
+
     def _ProcessError(self):
         if not self._Enabled:
             return
@@ -1510,7 +1527,7 @@ class DscParser(MetaFileParser):
         for PcdType in (MODEL_PCD_PATCHABLE_IN_MODULE, MODEL_PCD_DYNAMIC_DEFAULT, MODEL_PCD_DYNAMIC_HII,
                         MODEL_PCD_DYNAMIC_VPD, MODEL_PCD_DYNAMIC_EX_DEFAULT, MODEL_PCD_DYNAMIC_EX_HII,
                         MODEL_PCD_DYNAMIC_EX_VPD):
-            Records = self._RawTable.Query(PcdType, BelongsToItem= -1.0)
+            Records = self._RawTable.Query(PcdType, BelongsToItem=-1.0)
             for TokenSpaceGuid, PcdName, Value, Dummy2, Dummy3, Dummy4, ID, Line in Records:
                 Name = TokenSpaceGuid + '.' + PcdName
                 if Name not in GlobalData.gPlatformOtherPcds:
@@ -1565,8 +1582,8 @@ class DscParser(MetaFileParser):
                 # the precise number of line and return the evaluation result
                 #
                 EdkLogger.warn('Parser', "Suspicious expression: %s" % str(Excpt),
-                                File=self._FileWithError, ExtraData=' '.join(self._ValueList),
-                                Line=self._LineIndex + 1)
+                               File=self._FileWithError, ExtraData=' '.join(self._ValueList),
+                               Line=self._LineIndex + 1)
                 Result = Excpt.result
 
         if self._ItemType in [MODEL_META_DATA_CONDITIONAL_STATEMENT_IF,
@@ -1635,11 +1652,12 @@ class DscParser(MetaFileParser):
                     Owner = self._Content[self._ContentIndex - 1][8]
                 else:
                     Owner = self._Content[self._ContentIndex - 1][0]
-                IncludedFileTable = MetaFileStorage(self._RawTable.DB, IncludedFile1, MODEL_FILE_DSC, False, FromItem=FromItem)
+                IncludedFileTable = MetaFileStorage(self._RawTable.DB, IncludedFile1,
+                                                    MODEL_FILE_DSC, False, FromItem=FromItem)
                 Parser = DscParser(IncludedFile1, self._FileType, self._Arch, IncludedFileTable,
                                    Owner=Owner, From=FromItem)
 
-                self.IncludedFiles.add (IncludedFile1)
+                self.IncludedFiles.add(IncludedFile1)
 
                 # set the parser status with current status
                 Parser._SectionName = self._SectionName
@@ -1664,6 +1682,7 @@ class DscParser(MetaFileParser):
     def __ProcessSkuId(self):
         self._ValueList = [ReplaceMacro(Value, self._Macros, RaiseError=True)
                            for Value in self._ValueList]
+
     def __ProcessDefaultStores(self):
         self._ValueList = [ReplaceMacro(Value, self._Macros, RaiseError=True)
                            for Value in self._ValueList]
@@ -1716,61 +1735,63 @@ class DscParser(MetaFileParser):
         self._ValueList = [ReplaceMacro(Value, self._Macros, RaiseError=False)
                            for Value in self._ValueList]
 
-    def DisableOverrideComponent(self,module_id):
+    def DisableOverrideComponent(self, module_id):
         for ori_id in self._IdMapping:
             if self._IdMapping[ori_id] == module_id:
                 self._RawTable.DisableComponent(ori_id)
 
     _SectionParser = {
-        MODEL_META_DATA_HEADER                          :   _DefineParser,
-        MODEL_EFI_SKU_ID                                :   _SkuIdParser,
-        MODEL_EFI_DEFAULT_STORES                        :   _DefaultStoresParser,
-        MODEL_EFI_LIBRARY_INSTANCE                      :   _LibraryInstanceParser,
-        MODEL_EFI_LIBRARY_CLASS                         :   _LibraryClassParser,
-        MODEL_PCD_FIXED_AT_BUILD                        :   _PcdParser,
-        MODEL_PCD_PATCHABLE_IN_MODULE                   :   _PcdParser,
-        MODEL_PCD_FEATURE_FLAG                          :   _PcdParser,
-        MODEL_PCD_DYNAMIC_DEFAULT                       :   _PcdParser,
-        MODEL_PCD_DYNAMIC_HII                           :   _PcdParser,
-        MODEL_PCD_DYNAMIC_VPD                           :   _PcdParser,
-        MODEL_PCD_DYNAMIC_EX_DEFAULT                    :   _PcdParser,
-        MODEL_PCD_DYNAMIC_EX_HII                        :   _PcdParser,
-        MODEL_PCD_DYNAMIC_EX_VPD                        :   _PcdParser,
-        MODEL_META_DATA_COMPONENT                       :   _ComponentParser,
-        MODEL_META_DATA_BUILD_OPTION                    :   _BuildOptionParser,
-        MODEL_UNKNOWN                                   :   MetaFileParser._Skip,
-        MODEL_META_DATA_PACKAGE                         :   MetaFileParser._PackageParser,
-        MODEL_META_DATA_USER_EXTENSION                  :   MetaFileParser._SkipUserExtension,
-        MODEL_META_DATA_SECTION_HEADER                  :   MetaFileParser._SectionHeaderParser,
-        MODEL_META_DATA_SUBSECTION_HEADER               :   _SubsectionHeaderParser,
+        MODEL_META_DATA_HEADER: _DefineParser,
+        MODEL_EFI_SKU_ID: _SkuIdParser,
+        MODEL_EFI_DEFAULT_STORES: _DefaultStoresParser,
+        MODEL_EFI_LIBRARY_INSTANCE: _LibraryInstanceParser,
+        MODEL_EFI_LIBRARY_CLASS: _LibraryClassParser,
+        MODEL_PCD_FIXED_AT_BUILD: _PcdParser,
+        MODEL_PCD_PATCHABLE_IN_MODULE: _PcdParser,
+        MODEL_PCD_FEATURE_FLAG: _PcdParser,
+        MODEL_PCD_DYNAMIC_DEFAULT: _PcdParser,
+        MODEL_PCD_DYNAMIC_HII: _PcdParser,
+        MODEL_PCD_DYNAMIC_VPD: _PcdParser,
+        MODEL_PCD_DYNAMIC_EX_DEFAULT: _PcdParser,
+        MODEL_PCD_DYNAMIC_EX_HII: _PcdParser,
+        MODEL_PCD_DYNAMIC_EX_VPD: _PcdParser,
+        MODEL_META_DATA_COMPONENT: _ComponentParser,
+        MODEL_META_DATA_BUILD_OPTION: _BuildOptionParser,
+        MODEL_UNKNOWN: MetaFileParser._Skip,
+        MODEL_META_DATA_PACKAGE: MetaFileParser._PackageParser,
+        MODEL_META_DATA_USER_EXTENSION: MetaFileParser._SkipUserExtension,
+        MODEL_META_DATA_SECTION_HEADER: MetaFileParser._SectionHeaderParser,
+        MODEL_META_DATA_SUBSECTION_HEADER: _SubsectionHeaderParser,
     }
 
-## DEC file parser class
+# DEC file parser class
 #
 #   @param      FilePath        The path of platform description file
 #   @param      FileType        The raw data of DSC file
 #   @param      Table           Database used to retrieve module/package information
 #   @param      Macros          Macros used for replacement in file
 #
+
+
 class DecParser(MetaFileParser):
     # DEC file supported data types (one type per section)
     DataType = {
-        TAB_DEC_DEFINES.upper()                     :   MODEL_META_DATA_HEADER,
-        TAB_DSC_DEFINES_DEFINE                      :   MODEL_META_DATA_DEFINE,
-        TAB_INCLUDES.upper()                        :   MODEL_EFI_INCLUDE,
-        TAB_LIBRARY_CLASSES.upper()                 :   MODEL_EFI_LIBRARY_CLASS,
-        TAB_GUIDS.upper()                           :   MODEL_EFI_GUID,
-        TAB_PPIS.upper()                            :   MODEL_EFI_PPI,
-        TAB_PROTOCOLS.upper()                       :   MODEL_EFI_PROTOCOL,
-        TAB_PCDS_FIXED_AT_BUILD_NULL.upper()        :   MODEL_PCD_FIXED_AT_BUILD,
-        TAB_PCDS_PATCHABLE_IN_MODULE_NULL.upper()   :   MODEL_PCD_PATCHABLE_IN_MODULE,
-        TAB_PCDS_FEATURE_FLAG_NULL.upper()          :   MODEL_PCD_FEATURE_FLAG,
-        TAB_PCDS_DYNAMIC_NULL.upper()               :   MODEL_PCD_DYNAMIC,
-        TAB_PCDS_DYNAMIC_EX_NULL.upper()            :   MODEL_PCD_DYNAMIC_EX,
-        TAB_USER_EXTENSIONS.upper()                 :   MODEL_META_DATA_USER_EXTENSION,
+        TAB_DEC_DEFINES.upper(): MODEL_META_DATA_HEADER,
+        TAB_DSC_DEFINES_DEFINE: MODEL_META_DATA_DEFINE,
+        TAB_INCLUDES.upper(): MODEL_EFI_INCLUDE,
+        TAB_LIBRARY_CLASSES.upper(): MODEL_EFI_LIBRARY_CLASS,
+        TAB_GUIDS.upper(): MODEL_EFI_GUID,
+        TAB_PPIS.upper(): MODEL_EFI_PPI,
+        TAB_PROTOCOLS.upper(): MODEL_EFI_PROTOCOL,
+        TAB_PCDS_FIXED_AT_BUILD_NULL.upper(): MODEL_PCD_FIXED_AT_BUILD,
+        TAB_PCDS_PATCHABLE_IN_MODULE_NULL.upper(): MODEL_PCD_PATCHABLE_IN_MODULE,
+        TAB_PCDS_FEATURE_FLAG_NULL.upper(): MODEL_PCD_FEATURE_FLAG,
+        TAB_PCDS_DYNAMIC_NULL.upper(): MODEL_PCD_DYNAMIC,
+        TAB_PCDS_DYNAMIC_EX_NULL.upper(): MODEL_PCD_DYNAMIC_EX,
+        TAB_USER_EXTENSIONS.upper(): MODEL_META_DATA_USER_EXTENSION,
     }
 
-    ## Constructor of DecParser
+    # Constructor of DecParser
     #
     #  Initialize object of DecParser
     #
@@ -1786,7 +1807,7 @@ class DecParser(MetaFileParser):
         MetaFileParser.__init__(self, FilePath, FileType, Arch, Table, -1)
         self._Comments = []
         self._Version = 0x00010005  # Only EDK2 dec file is supported
-        self._AllPCDs = [] # Only for check duplicate PCD
+        self._AllPCDs = []  # Only for check duplicate PCD
         self._AllPcdDict = {}
 
         self._CurrentStructurePcdName = ""
@@ -1795,7 +1816,7 @@ class DecParser(MetaFileParser):
 
         self._RestofValue = ""
 
-    ## Parser starter
+    # Parser starter
     def Start(self):
         Content = ''
         try:
@@ -1829,7 +1850,7 @@ class DecParser(MetaFileParser):
             if self._SectionType == MODEL_UNKNOWN:
                 EdkLogger.error("Parser", FORMAT_INVALID,
                                 ""
-                                "Not able to determine \"%s\" in which section."%self._CurrentLine,
+                                "Not able to determine \"%s\" in which section." % self._CurrentLine,
                                 self.MetaFile, self._LineIndex + 1)
             elif len(self._SectionType) == 0:
                 self._Comments = []
@@ -1861,7 +1882,7 @@ class DecParser(MetaFileParser):
                     self._LineIndex + 1,
                     - 1,
                     0
-                    )
+                )
                 for Comment, LineNo in self._Comments:
                     self._Store(
                         MODEL_META_DATA_COMMENT,
@@ -1876,21 +1897,21 @@ class DecParser(MetaFileParser):
                         LineNo,
                         - 1,
                         0
-                        )
+                    )
             self._Comments = []
         if self._DefinesCount > 1:
-            EdkLogger.error('Parser', FORMAT_INVALID, 'Multiple [Defines] section is exist.', self.MetaFile )
+            EdkLogger.error('Parser', FORMAT_INVALID, 'Multiple [Defines] section is exist.', self.MetaFile)
         if self._DefinesCount == 0:
             EdkLogger.error('Parser', FORMAT_INVALID, 'No [Defines] section exist.', self.MetaFile)
         self._Done()
 
-
-    ## Section header parser
+    # Section header parser
     #
     #   The section header is always in following format:
     #
     #       [section_name.arch<.platform|module_type>]
     #
+
     def _SectionHeaderParser(self):
         self._Scope = []
         self._SectionName = ''
@@ -1919,13 +1940,13 @@ class DecParser(MetaFileParser):
 
             if MODEL_PCD_FEATURE_FLAG in self._SectionType and len(self._SectionType) > 1:
                 EdkLogger.error(
-                            'Parser',
-                            FORMAT_INVALID,
-                            "%s must not be in the same section of other types of PCD" % TAB_PCDS_FEATURE_FLAG_NULL,
-                            File=self.MetaFile,
-                            Line=self._LineIndex + 1,
-                            ExtraData=self._CurrentLine
-                            )
+                    'Parser',
+                    FORMAT_INVALID,
+                    "%s must not be in the same section of other types of PCD" % TAB_PCDS_FEATURE_FLAG_NULL,
+                    File=self.MetaFile,
+                    Line=self._LineIndex + 1,
+                    ExtraData=self._CurrentLine
+                )
             # S1 is always Arch
             if len(ItemList) > 1:
                 S1 = ItemList[1].upper()
@@ -1956,7 +1977,7 @@ class DecParser(MetaFileParser):
             EdkLogger.error('Parser', FORMAT_INVALID, "Can't mix section tags without the Private attribute with section tags with the Private attribute",
                             File=self.MetaFile, Line=self._LineIndex + 1, ExtraData=self._CurrentLine)
 
-    ## [guids], [ppis] and [protocols] section parser
+    # [guids], [ppis] and [protocols] section parser
     @ParseMacro
     def _GuidParser(self):
         TokenList = GetSplitValueList(self._CurrentLine, TAB_EQUAL_SPLIT, 1)
@@ -1974,15 +1995,15 @@ class DecParser(MetaFileParser):
                             File=self.MetaFile, Line=self._LineIndex + 1)
         if TokenList[1][0] != '{' or TokenList[1][-1] != '}' or GuidStructureStringToGuidString(TokenList[1]) == '':
             EdkLogger.error('Parser', FORMAT_INVALID, "Invalid GUID value format",
-                            ExtraData=self._CurrentLine + \
-                                      " (<CName> = <GuidValueInCFormat:{8,4,4,{2,2,2,2,2,2,2,2}}>)",
+                            ExtraData=self._CurrentLine +
+                            " (<CName> = <GuidValueInCFormat:{8,4,4,{2,2,2,2,2,2,2,2}}>)",
                             File=self.MetaFile, Line=self._LineIndex + 1)
         self._ValueList[0] = TokenList[0]
         self._ValueList[1] = TokenList[1]
         if self._ValueList[0] not in self._GuidDict:
             self._GuidDict[self._ValueList[0]] = self._ValueList[1]
 
-    def ParsePcdName(self,namelist):
+    def ParsePcdName(self, namelist):
         if "[" in namelist[1]:
             pcdname = namelist[1][:namelist[1].index("[")]
             arrayindex = namelist[1][namelist[1].index("["):]
@@ -1990,10 +2011,10 @@ class DecParser(MetaFileParser):
             if len(namelist) == 2:
                 namelist.append(arrayindex)
             else:
-                namelist[2] = ".".join((arrayindex,namelist[2]))
+                namelist[2] = ".".join((arrayindex, namelist[2]))
         return namelist
 
-    ## PCD sections parser
+    # PCD sections parser
     #
     #   [PcdsFixedAtBuild]
     #   [PcdsPatchableInModule]
@@ -2037,7 +2058,7 @@ class DecParser(MetaFileParser):
                     if PcdNames[1].strip().endswith("]"):
                         PcdName = PcdNames[1][:PcdNames[1].index('[')]
                         Index = PcdNames[1][PcdNames[1].index('['):]
-                        self._ValueList[0] = TAB_SPLIT.join((PcdNames[0],PcdName))
+                        self._ValueList[0] = TAB_SPLIT.join((PcdNames[0], PcdName))
                         self._ValueList[1] = Index
                         self._ValueList[2] = PcdTockens[1]
                     else:
@@ -2045,15 +2066,15 @@ class DecParser(MetaFileParser):
                 else:
                     if self._CurrentStructurePcdName != TAB_SPLIT.join(PcdNames[:2]):
                         EdkLogger.error('Parser', FORMAT_INVALID, "Pcd Name does not match: %s and %s " % (self._CurrentStructurePcdName, TAB_SPLIT.join(PcdNames[:2])),
-                                File=self.MetaFile, Line=self._LineIndex + 1)
+                                        File=self.MetaFile, Line=self._LineIndex + 1)
                     self._ValueList[1] = TAB_SPLIT.join(PcdNames[2:])
                     self._ValueList[2] = PcdTockens[1]
         if not self._CurrentStructurePcdName:
             if self._PcdDataTypeCODE:
                 if ")}" in self._CurrentLine:
-                    ValuePart,RestofValue = self._CurrentLine.split(")}")
+                    ValuePart, RestofValue = self._CurrentLine.split(")}")
                     self._PcdCodeValue = self._PcdCodeValue + "\n " + ValuePart
-                    self._CurrentLine = "|".join((self._CurrentPcdName, self._PcdCodeValue,RestofValue))
+                    self._CurrentLine = "|".join((self._CurrentPcdName, self._PcdCodeValue, RestofValue))
                     self._PcdDataTypeCODE = False
                     self._PcdCodeValue = ""
                 else:
@@ -2077,28 +2098,27 @@ class DecParser(MetaFileParser):
             # check PCD information
             if self._ValueList[0] == '' or self._ValueList[1] == '':
                 EdkLogger.error('Parser', FORMAT_INVALID, "No token space GUID or PCD name specified",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
             # check format of token space GUID CName
             if not ValueRe.match(self._ValueList[0]):
                 EdkLogger.error('Parser', FORMAT_INVALID, "The format of the token space GUID CName is invalid. The correct format is '(a-zA-Z_)[a-zA-Z0-9_]*'",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
             # check format of PCD CName
             if not ValueRe.match(self._ValueList[1]):
                 EdkLogger.error('Parser', FORMAT_INVALID, "The format of the PCD CName is invalid. The correct format is '(a-zA-Z_)[a-zA-Z0-9_]*'",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
             # check PCD datum information
             if len(TokenList) < 2 or TokenList[1] == '':
                 EdkLogger.error('Parser', FORMAT_INVALID, "No PCD Datum information given",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
-
 
             ValueRe = re.compile(r'^\s*L?\".*\|.*\"')
             PtrValue = ValueRe.findall(TokenList[1])
@@ -2111,30 +2131,29 @@ class DecParser(MetaFileParser):
             else:
                 ValueList = AnalyzePcdExpression(TokenList[1])
 
-
             # check if there's enough datum information given
             if len(ValueList) != 3:
                 EdkLogger.error('Parser', FORMAT_INVALID, "Invalid PCD Datum information given",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
             # check default value
             if ValueList[0] == '':
                 EdkLogger.error('Parser', FORMAT_INVALID, "Missing DefaultValue in PCD Datum information",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
             # check datum type
             if ValueList[1] == '':
                 EdkLogger.error('Parser', FORMAT_INVALID, "Missing DatumType in PCD Datum information",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
             # check token of the PCD
             if ValueList[2] == '':
                 EdkLogger.error('Parser', FORMAT_INVALID, "Missing Token in PCD Datum information",
-                                ExtraData=self._CurrentLine + \
-                                          " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
+                                ExtraData=self._CurrentLine +
+                                " (<TokenSpaceGuidCName>.<PcdCName>|<DefaultValue>|<DatumType>|<Token>)",
                                 File=self.MetaFile, Line=self._LineIndex + 1)
 
             PcdValue = ValueList[0]
@@ -2143,7 +2162,8 @@ class DecParser(MetaFileParser):
                     self._GuidDict.update(self._AllPcdDict)
                     ValueList[0] = ValueExpressionEx(ValueList[0], ValueList[1], self._GuidDict)(True)
                 except BadExpression as Value:
-                    EdkLogger.error('Parser', FORMAT_INVALID, Value, ExtraData=self._CurrentLine, File=self.MetaFile, Line=self._LineIndex + 1)
+                    EdkLogger.error('Parser', FORMAT_INVALID, Value, ExtraData=self._CurrentLine,
+                                    File=self.MetaFile, Line=self._LineIndex + 1)
             # check format of default value against the datum type
             IsValid, Cause = CheckPcdDatum(ValueList[1], ValueList[0])
             if not IsValid:
@@ -2172,20 +2192,21 @@ class DecParser(MetaFileParser):
             self._ValueList[2] = ValueList[0].strip() + '|' + ValueList[1].strip() + '|' + ValueList[2].strip()
 
     _SectionParser = {
-        MODEL_META_DATA_HEADER          :   MetaFileParser._DefineParser,
-        MODEL_EFI_INCLUDE               :   MetaFileParser._PathParser,
-        MODEL_EFI_LIBRARY_CLASS         :   MetaFileParser._PathParser,
-        MODEL_EFI_GUID                  :   _GuidParser,
-        MODEL_EFI_PPI                   :   _GuidParser,
-        MODEL_EFI_PROTOCOL              :   _GuidParser,
-        MODEL_PCD_FIXED_AT_BUILD        :   _PcdParser,
-        MODEL_PCD_PATCHABLE_IN_MODULE   :   _PcdParser,
-        MODEL_PCD_FEATURE_FLAG          :   _PcdParser,
-        MODEL_PCD_DYNAMIC               :   _PcdParser,
-        MODEL_PCD_DYNAMIC_EX            :   _PcdParser,
-        MODEL_UNKNOWN                   :   MetaFileParser._Skip,
-        MODEL_META_DATA_USER_EXTENSION  :   MetaFileParser._SkipUserExtension,
+        MODEL_META_DATA_HEADER: MetaFileParser._DefineParser,
+        MODEL_EFI_INCLUDE: MetaFileParser._PathParser,
+        MODEL_EFI_LIBRARY_CLASS: MetaFileParser._PathParser,
+        MODEL_EFI_GUID: _GuidParser,
+        MODEL_EFI_PPI: _GuidParser,
+        MODEL_EFI_PROTOCOL: _GuidParser,
+        MODEL_PCD_FIXED_AT_BUILD: _PcdParser,
+        MODEL_PCD_PATCHABLE_IN_MODULE: _PcdParser,
+        MODEL_PCD_FEATURE_FLAG: _PcdParser,
+        MODEL_PCD_DYNAMIC: _PcdParser,
+        MODEL_PCD_DYNAMIC_EX: _PcdParser,
+        MODEL_UNKNOWN: MetaFileParser._Skip,
+        MODEL_META_DATA_USER_EXTENSION: MetaFileParser._SkipUserExtension,
     }
+
 
 ##
 #
@@ -2194,4 +2215,3 @@ class DecParser(MetaFileParser):
 #
 if __name__ == '__main__':
     pass
-

--- a/edk2basetools/build/build.py
+++ b/edk2basetools/build/build.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # build a platform or a module
 #
 #  Copyright (c) 2014, Hewlett-Packard Development Company, L.P.<BR>
@@ -23,16 +23,16 @@ import time
 import platform
 import traceback
 import multiprocessing
-from threading import Thread,Event,BoundedSemaphore
+from threading import Thread, Event, BoundedSemaphore
 import threading
 from linecache import getlines
-from subprocess import Popen,PIPE, STDOUT
+from subprocess import Popen, PIPE, STDOUT
 from collections import OrderedDict, defaultdict
 
 from edk2basetools.AutoGen.PlatformAutoGen import PlatformAutoGen
 from edk2basetools.AutoGen.ModuleAutoGen import ModuleAutoGen
 from edk2basetools.AutoGen.WorkspaceAutoGen import WorkspaceAutoGen
-from edk2basetools.AutoGen.AutoGenWorker import AutoGenWorkerInProcess,AutoGenManager,\
+from edk2basetools.AutoGen.AutoGenWorker import AutoGenWorkerInProcess, AutoGenManager,\
     LogAgent
 from edk2basetools.AutoGen import GenMake
 from edk2basetools.Common import Misc as Utils
@@ -40,7 +40,7 @@ from edk2basetools.Common import Misc as Utils
 from edk2basetools.Common.TargetTxtClassObject import TargetTxtDict
 from edk2basetools.Common.ToolDefClassObject import ToolDefDict
 from edk2basetools.build.buildoptions import MyOptionParser
-from edk2basetools.Common.Misc import PathClass,SaveFileOnChange,RemoveDirectory
+from edk2basetools.Common.Misc import PathClass, SaveFileOnChange, RemoveDirectory
 from edk2basetools.Common.StringUtils import NormPath
 from edk2basetools.Common.MultipleWorkspace import MultipleWorkspace as mws
 from edk2basetools.Common.BuildToolError import *
@@ -50,7 +50,7 @@ import edk2basetools.Common.EdkLogger as EdkLogger
 from edk2basetools.Workspace.WorkspaceDatabase import BuildDB
 
 from edk2basetools.build.BuildReport import BuildReport
-from edk2basetools.GenPatchPcdTable.GenPatchPcdTable import PeImageClass,parsePcdInfoFromMapFile
+from edk2basetools.GenPatchPcdTable.GenPatchPcdTable import PeImageClass, parsePcdInfoFromMapFile
 from edk2basetools.PatchPcdValue.PatchPcdValue import PatchBinaryFile
 
 import edk2basetools.Common.GlobalData as GlobalData
@@ -64,19 +64,21 @@ from edk2basetools.AutoGen.IncludesAutoGen import IncludesAutoGen
 from edk2basetools.GenFds.GenFds import resetFdsGlobalVariable
 from edk2basetools.AutoGen.AutoGen import CalculatePriorityValue
 
-## standard targets of build command
+# standard targets of build command
 gSupportedTarget = ['all', 'genc', 'genmake', 'modules', 'libraries', 'fds', 'clean', 'cleanall', 'cleanlib', 'run']
 
-## build configuration file
+# build configuration file
 
 TemporaryTablePattern = re.compile(r'^_\d+_\d+_[a-fA-F0-9]+$')
 TmpTableDict = {}
 
-## Check environment PATH variable to make sure the specified tool is found
+# Check environment PATH variable to make sure the specified tool is found
 #
 #   If the tool is found in the PATH, then True is returned
 #   Otherwise, False is returned
 #
+
+
 def IsToolInPath(tool):
     if 'PATHEXT' in os.environ:
         extns = os.environ['PATHEXT'].split(os.path.pathsep)
@@ -88,7 +90,7 @@ def IsToolInPath(tool):
                 return True
     return False
 
-## Check environment variables
+# Check environment variables
 #
 #  Check environment variables that must be set for build. Currently they are
 #
@@ -99,6 +101,8 @@ def IsToolInPath(tool):
 #   If any of above environment variable is not set or has error, the build
 #   will be broken.
 #
+
+
 def CheckEnvVariable():
     # check WORKSPACE
     if "WORKSPACE" not in os.environ:
@@ -123,7 +127,6 @@ def CheckEnvVariable():
             elif ' ' in Path:
                 EdkLogger.error("build", FORMAT_NOT_SUPPORTED, "No space is allowed in PACKAGES_PATH", ExtraData=Path)
 
-
     os.environ["EDK_TOOLS_PATH"] = os.path.normcase(os.environ["EDK_TOOLS_PATH"])
 
     # check EDK_TOOLS_PATH
@@ -138,10 +141,10 @@ def CheckEnvVariable():
 
     GlobalData.gWorkspace = WorkspaceDir
 
-    GlobalData.gGlobalDefines["WORKSPACE"]  = WorkspaceDir
+    GlobalData.gGlobalDefines["WORKSPACE"] = WorkspaceDir
     GlobalData.gGlobalDefines["EDK_TOOLS_PATH"] = os.environ["EDK_TOOLS_PATH"]
 
-## Get normalized file path
+# Get normalized file path
 #
 # Convert the path to be local format, and remove the WORKSPACE path at the
 # beginning if the file path is given in full path.
@@ -151,6 +154,8 @@ def CheckEnvVariable():
 #
 # @retval string        The normalized file path
 #
+
+
 def NormFile(FilePath, Workspace):
     # check if the path is absolute or relative
     if os.path.isabs(FilePath):
@@ -161,7 +166,8 @@ def NormFile(FilePath, Workspace):
 
     # check if the file path exists or not
     if not os.path.isfile(FileFullPath):
-        EdkLogger.error("build", FILE_NOT_FOUND, ExtraData="\t%s (Please give file in absolute path or relative to WORKSPACE)" % FileFullPath)
+        EdkLogger.error("build", FILE_NOT_FOUND,
+                        ExtraData="\t%s (Please give file in absolute path or relative to WORKSPACE)" % FileFullPath)
 
     # remove workspace directory from the beginning part of the file path
     if Workspace[-1] in ["\\", "/"]:
@@ -169,7 +175,7 @@ def NormFile(FilePath, Workspace):
     else:
         return FileFullPath[(len(Workspace) + 1):]
 
-## Get the output of an external program
+# Get the output of an external program
 #
 # This is the entrance method of thread reading output of an external program and
 # putting them in STDOUT/STDERR of current program.
@@ -178,7 +184,9 @@ def NormFile(FilePath, Workspace):
 # @param  To        The stream message put on
 # @param  ExitFlag  The flag used to indicate stopping reading
 #
-def ReadMessage(From, To, ExitFlag,MemTo=None):
+
+
+def ReadMessage(From, To, ExitFlag, MemTo=None):
     while True:
         # read one line a time
         Line = From.readline()
@@ -186,7 +194,7 @@ def ReadMessage(From, To, ExitFlag,MemTo=None):
         if Line is not None and Line != b"":
             LineStr = Line.rstrip().decode(encoding='utf-8', errors='ignore')
             if MemTo is not None:
-                if "Note: including file:" ==  LineStr.lstrip()[:21]:
+                if "Note: including file:" == LineStr.lstrip()[:21]:
                     MemTo.append(LineStr)
                 else:
                     To(LineStr)
@@ -198,12 +206,13 @@ def ReadMessage(From, To, ExitFlag,MemTo=None):
         if ExitFlag.is_set():
             break
 
+
 class MakeSubProc(Popen):
-    def __init__(self,*args, **argv):
-        super(MakeSubProc,self).__init__(*args, **argv)
+    def __init__(self, *args, **argv):
+        super(MakeSubProc, self).__init__(*args, **argv)
         self.ProcOut = []
 
-## Launch an external program
+# Launch an external program
 #
 # This method will call subprocess.Popen to execute an external program with
 # given options in specified directory. Because of the dead-lock issue during
@@ -213,7 +222,9 @@ class MakeSubProc(Popen):
 # @param  Command               A list or string containing the call of the program
 # @param  WorkingDir            The directory in which the program will be running
 #
-def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
+
+
+def LaunchCommand(Command, WorkingDir, ModuleAuto=None):
     BeginTime = time.time()
     # if working directory doesn't exist, Popen() will raise an exception
     if not os.path.isdir(WorkingDir):
@@ -238,15 +249,14 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
         EndOfProcedure = Event()
         EndOfProcedure.clear()
         if Proc.stdout:
-            StdOutThread = Thread(target=ReadMessage, args=(Proc.stdout, EdkLogger.info, EndOfProcedure,Proc.ProcOut))
+            StdOutThread = Thread(target=ReadMessage, args=(Proc.stdout, EdkLogger.info, EndOfProcedure, Proc.ProcOut))
             StdOutThread.name = "STDOUT-Redirector"
             StdOutThread.daemon = False
             StdOutThread.start()
 
-
         # waiting for program exit
         Proc.wait()
-    except: # in case of aborting
+    except:  # in case of aborting
         # terminate the threads redirecting the program output
         EdkLogger.quiet("(Python %s on %s) " % (platform.python_version(), sys.platform) + traceback.format_exc())
         if EndOfProcedure is not None:
@@ -254,7 +264,8 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
         if Proc is None:
             if not isinstance(Command, type("")):
                 Command = " ".join(Command)
-            EdkLogger.error("build", COMMAND_FAILURE, "Failed to start command", ExtraData="%s [%s]" % (Command, WorkingDir))
+            EdkLogger.error("build", COMMAND_FAILURE, "Failed to start command",
+                            ExtraData="%s [%s]" % (Command, WorkingDir))
 
     if Proc.stdout:
         StdOutThread.join()
@@ -273,7 +284,7 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
 
         EdkLogger.error("build", COMMAND_FAILURE, ExtraData="%s [%s]" % (Command, WorkingDir))
     if ModuleAuto:
-        iau = IncludesAutoGen(WorkingDir,ModuleAuto)
+        iau = IncludesAutoGen(WorkingDir, ModuleAuto)
         if ModuleAuto.ToolChainFamily == TAB_COMPILER_MSFT:
             iau.CreateDepsFileForMsvc(Proc.ProcOut)
         else:
@@ -284,7 +295,7 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
         iau.CreateDepsTarget()
     return "%dms" % (int(round((time.time() - BeginTime) * 1000)))
 
-## The smallest unit that can be built in multi-thread build mode
+# The smallest unit that can be built in multi-thread build mode
 #
 # This is the base class of build unit. The "Obj" parameter must provide
 # __str__(), __eq__() and __hash__() methods. Otherwise there could be build units
@@ -292,8 +303,10 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
 #
 # Currently the "Obj" should be only ModuleAutoGen or PlatformAutoGen objects.
 #
+
+
 class BuildUnit:
-    ## The constructor
+    # The constructor
     #
     #   @param  self        The object pointer
     #   @param  Obj         The object the build is working on
@@ -311,20 +324,20 @@ class BuildUnit:
             EdkLogger.error("build", OPTION_MISSING,
                             "No build command found for this module. "
                             "Please check your setting of %s_%s_%s_MAKE_PATH in Conf/tools_def.txt file." %
-                                (Obj.BuildTarget, Obj.ToolChain, Obj.Arch),
+                            (Obj.BuildTarget, Obj.ToolChain, Obj.Arch),
                             ExtraData=str(Obj))
 
-
-    ## str() method
+    # str() method
     #
     #   It just returns the string representation of self.BuildObject
     #
     #   @param  self        The object pointer
     #
+
     def __str__(self):
         return str(self.BuildObject)
 
-    ## "==" operator method
+    # "==" operator method
     #
     #   It just compares self.BuildObject with "Other". So self.BuildObject must
     #   provide its own __eq__() method.
@@ -334,10 +347,10 @@ class BuildUnit:
     #
     def __eq__(self, Other):
         return Other and self.BuildObject == Other.BuildObject \
-                and Other.BuildObject \
-                and self.BuildObject.Arch == Other.BuildObject.Arch
+            and Other.BuildObject \
+            and self.BuildObject.Arch == Other.BuildObject.Arch
 
-    ## hash() method
+    # hash() method
     #
     #   It just returns the hash value of self.BuildObject which must be hashable.
     #
@@ -349,7 +362,7 @@ class BuildUnit:
     def __repr__(self):
         return repr(self.BuildObject)
 
-## The smallest module unit that can be built by nmake/make command in multi-thread build mode
+# The smallest module unit that can be built by nmake/make command in multi-thread build mode
 #
 # This class is for module build by nmake/make build system. The "Obj" parameter
 # must provide __str__(), __eq__() and __hash__() methods. Otherwise there could
@@ -357,20 +370,22 @@ class BuildUnit:
 #
 # Currently the "Obj" should be only ModuleAutoGen object.
 #
+
+
 class ModuleMakeUnit(BuildUnit):
-    ## The constructor
+    # The constructor
     #
     #   @param  self        The object pointer
     #   @param  Obj         The ModuleAutoGen object the build is working on
     #   @param  Target      The build target name, one of gSupportedTarget
     #
-    def __init__(self, Obj, BuildCommand,Target):
-        Dependency = [ModuleMakeUnit(La, BuildCommand,Target) for La in Obj.LibraryAutoGenList]
+    def __init__(self, Obj, BuildCommand, Target):
+        Dependency = [ModuleMakeUnit(La, BuildCommand, Target) for La in Obj.LibraryAutoGenList]
         BuildUnit.__init__(self, Obj, BuildCommand, Target, Dependency, Obj.MakeFileDir)
         if Target in [None, "", "all"]:
             self.Target = "tbuild"
 
-## The smallest platform unit that can be built by nmake/make command in multi-thread build mode
+# The smallest platform unit that can be built by nmake/make command in multi-thread build mode
 #
 # This class is for platform build by nmake/make build system. The "Obj" parameter
 # must provide __str__(), __eq__() and __hash__() methods. Otherwise there could
@@ -378,8 +393,10 @@ class ModuleMakeUnit(BuildUnit):
 #
 # Currently the "Obj" should be only PlatformAutoGen object.
 #
+
+
 class PlatformMakeUnit(BuildUnit):
-    ## The constructor
+    # The constructor
     #
     #   @param  self        The object pointer
     #   @param  Obj         The PlatformAutoGen object the build is working on
@@ -387,14 +404,16 @@ class PlatformMakeUnit(BuildUnit):
     #
     def __init__(self, Obj, BuildCommand, Target):
         Dependency = [ModuleMakeUnit(Lib, BuildCommand, Target) for Lib in self.BuildObject.LibraryAutoGenList]
-        Dependency.extend([ModuleMakeUnit(Mod, BuildCommand,Target) for Mod in self.BuildObject.ModuleAutoGenList])
+        Dependency.extend([ModuleMakeUnit(Mod, BuildCommand, Target) for Mod in self.BuildObject.ModuleAutoGenList])
         BuildUnit.__init__(self, Obj, BuildCommand, Target, Dependency, Obj.MakeFileDir)
 
-## The class representing the task of a module build or platform build
+# The class representing the task of a module build or platform build
 #
 # This class manages the build tasks in multi-thread build mode. Its jobs include
 # scheduling thread running, catching thread error, monitor the thread status, etc.
 #
+
+
 class BuildTask:
     # queue for tasks waiting for schedule
     _PendingQueue = OrderedDict()
@@ -423,7 +442,7 @@ class BuildTask:
     _SchedulerStopped = threading.Event()
     _SchedulerStopped.set()
 
-    ## Start the task scheduler thread
+    # Start the task scheduler thread
     #
     #   @param  MaxThreadNumber     The maximum thread number
     #   @param  ExitFlag            Flag used to end the scheduler
@@ -438,7 +457,7 @@ class BuildTask:
         while not BuildTask.IsOnGoing():
             time.sleep(0.01)
 
-    ## Scheduler method
+    # Scheduler method
     #
     #   @param  MaxThreadNumber     The maximum thread number
     #   @param  ExitFlag            Flag used to end the scheduler
@@ -453,7 +472,7 @@ class BuildTask:
             # scheduling loop, which will exits when no pending/ready task and
             # indicated to do so, or there's error in running thread
             #
-            while (len(BuildTask._PendingQueue) > 0 or len(BuildTask._ReadyQueue) > 0 \
+            while (len(BuildTask._PendingQueue) > 0 or len(BuildTask._ReadyQueue) > 0
                    or not ExitFlag.is_set()) and not BuildTask._ErrorFlag.is_set():
                 EdkLogger.debug(EdkLogger.DEBUG_8, "Pending Queue (%d), Ready Queue (%d)"
                                 % (len(BuildTask._PendingQueue), len(BuildTask._ReadyQueue)))
@@ -519,26 +538,26 @@ class BuildTask:
         BuildTask._TaskQueue.clear()
         BuildTask._SchedulerStopped.set()
 
-    ## Wait for all running method exit
+    # Wait for all running method exit
     #
     @staticmethod
     def WaitForComplete():
         BuildTask._SchedulerStopped.wait()
 
-    ## Check if the scheduler is running or not
+    # Check if the scheduler is running or not
     #
     @staticmethod
     def IsOnGoing():
         return not BuildTask._SchedulerStopped.is_set()
 
-    ## Abort the build
+    # Abort the build
     @staticmethod
     def Abort():
         if BuildTask.IsOnGoing():
             BuildTask._ErrorFlag.set()
             BuildTask.WaitForComplete()
 
-    ## Check if there's error in running thread
+    # Check if there's error in running thread
     #
     #   Since the main thread cannot catch exceptions in other thread, we have to
     #   use threading.Event to communicate this formation to main thread.
@@ -547,7 +566,7 @@ class BuildTask:
     def HasError():
         return BuildTask._ErrorFlag.is_set()
 
-    ## Get error message in running thread
+    # Get error message in running thread
     #
     #   Since the main thread cannot catch exceptions in other thread, we have to
     #   use a static variable to communicate this message to main thread.
@@ -556,7 +575,7 @@ class BuildTask:
     def GetErrorMessage():
         return BuildTask._ErrorMessage
 
-    ## Factory method to create a BuildTask object
+    # Factory method to create a BuildTask object
     #
     #   This method will check if a module is building or has been built. And if
     #   true, just return the associated BuildTask object in the _TaskQueue. If
@@ -582,7 +601,7 @@ class BuildTask:
 
         return Bt
 
-    ## The real constructor of BuildTask
+    # The real constructor of BuildTask
     #
     #   @param  BuildItem       A BuildUnit object representing a build object
     #   @param  Dependency      The dependent build object of BuildItem
@@ -599,7 +618,7 @@ class BuildTask:
         # flag indicating build completes, used to avoid unnecessary re-build
         self.CompleteFlag = False
 
-    ## Check if all dependent build tasks are completed or not
+    # Check if all dependent build tasks are completed or not
     #
     def IsReady(self):
         ReadyFlag = True
@@ -611,7 +630,7 @@ class BuildTask:
 
         return ReadyFlag
 
-    ## Add dependent build task
+    # Add dependent build task
     #
     #   @param  Dependency      The list of dependent build objects
     #
@@ -620,14 +639,14 @@ class BuildTask:
             if not Dep.BuildObject.IsBinaryModule and not Dep.BuildObject.CanSkipbyCache(GlobalData.gModuleCacheHit):
                 self.DependencyList.append(BuildTask.New(Dep))    # BuildTask list
 
-    ## The thread wrapper of LaunchCommand function
+    # The thread wrapper of LaunchCommand function
     #
     # @param  Command               A list or string contains the call of the command
     # @param  WorkingDir            The directory in which the program will be running
     #
     def _CommandThread(self, Command, WorkingDir):
         try:
-            self.BuildItem.BuildObject.BuildTime = LaunchCommand(Command, WorkingDir,self.BuildItem.BuildObject)
+            self.BuildItem.BuildObject.BuildTime = LaunchCommand(Command, WorkingDir, self.BuildItem.BuildObject)
             self.CompleteFlag = True
 
             # Run hash operation post dependency to account for libs
@@ -647,7 +666,7 @@ class BuildTask:
                                                                   self.BuildItem.BuildObject.Arch,
                                                                   self.BuildItem.BuildObject.ToolChain,
                                                                   self.BuildItem.BuildObject.BuildTarget
-                                                                 )
+                                                                  )
             EdkLogger.SetLevel(EdkLogger.ERROR)
             BuildTask._ErrorFlag.set()
             BuildTask._ErrorMessage = "%s broken\n    %s [%s]" % \
@@ -659,7 +678,7 @@ class BuildTask:
         BuildTask._RunningQueueLock.release()
         BuildTask._Thread.release()
 
-    ## Start build task thread
+    # Start build task thread
     #
     def Start(self):
         EdkLogger.quiet("Building ... %s" % repr(self.BuildItem))
@@ -669,10 +688,12 @@ class BuildTask:
         self.BuildTread.daemon = False
         self.BuildTread.start()
 
-## The class contains the information related to EFI image
+# The class contains the information related to EFI image
 #
+
+
 class PeImageInfo():
-    ## Constructor
+    # Constructor
     #
     # Constructor will load all required image information.
     #
@@ -684,15 +705,15 @@ class PeImageInfo():
     #   @param  ImageClass        PeImage Information
     #
     def __init__(self, BaseName, Guid, Arch, OutputDir, DebugDir, ImageClass):
-        self.BaseName         = BaseName
-        self.Guid             = Guid
-        self.Arch             = Arch
-        self.OutputDir        = OutputDir
-        self.DebugDir         = DebugDir
-        self.Image            = ImageClass
-        self.Image.Size       = (self.Image.Size // 0x1000 + 1) * 0x1000
+        self.BaseName = BaseName
+        self.Guid = Guid
+        self.Arch = Arch
+        self.OutputDir = OutputDir
+        self.DebugDir = DebugDir
+        self.Image = ImageClass
+        self.Image.Size = (self.Image.Size // 0x1000 + 1) * 0x1000
 
-## The class implementing the EDK2 build process
+# The class implementing the EDK2 build process
 #
 #   The build process includes:
 #       1. Load configuration from target.txt and tools_def.txt in $(WORKSPACE)/Conf
@@ -702,8 +723,10 @@ class PeImageInfo():
 #       5. Create AutoGen files (C code file, depex file, makefile) if necessary
 #       6. Call build command
 #
+
+
 class Build():
-    ## Constructor
+    # Constructor
     #
     # Constructor will load all necessary configurations, parse platform, modules
     # and packages and the establish a database for AutoGen.
@@ -712,53 +735,56 @@ class Build():
     #   @param  WorkspaceDir        The directory of workspace
     #   @param  BuildOptions        Build options passed from command line
     #
-    def __init__(self, Target, WorkspaceDir, BuildOptions,log_q):
-        self.WorkspaceDir   = WorkspaceDir
-        self.Target         = Target
-        self.PlatformFile   = BuildOptions.PlatformFile
-        self.ModuleFile     = BuildOptions.ModuleFile
-        self.ArchList       = BuildOptions.TargetArch
-        self.ToolChainList  = BuildOptions.ToolChain
-        self.BuildTargetList= BuildOptions.BuildTarget
-        self.Fdf            = BuildOptions.FdfFile
-        self.FdList         = BuildOptions.RomImage
-        self.FvList         = BuildOptions.FvImage
-        self.CapList        = BuildOptions.CapName
-        self.SilentMode     = BuildOptions.SilentMode
-        self.ThreadNumber   = 1
-        self.SkipAutoGen    = BuildOptions.SkipAutoGen
-        self.Reparse        = BuildOptions.Reparse
-        self.SkuId          = BuildOptions.SkuId
+    def __init__(self, Target, WorkspaceDir, BuildOptions, log_q):
+        self.WorkspaceDir = WorkspaceDir
+        self.Target = Target
+        self.PlatformFile = BuildOptions.PlatformFile
+        self.ModuleFile = BuildOptions.ModuleFile
+        self.ArchList = BuildOptions.TargetArch
+        self.ToolChainList = BuildOptions.ToolChain
+        self.BuildTargetList = BuildOptions.BuildTarget
+        self.Fdf = BuildOptions.FdfFile
+        self.FdList = BuildOptions.RomImage
+        self.FvList = BuildOptions.FvImage
+        self.CapList = BuildOptions.CapName
+        self.SilentMode = BuildOptions.SilentMode
+        self.ThreadNumber = 1
+        self.SkipAutoGen = BuildOptions.SkipAutoGen
+        self.Reparse = BuildOptions.Reparse
+        self.SkuId = BuildOptions.SkuId
         if self.SkuId:
             GlobalData.gSKUID_CMD = self.SkuId
         self.ConfDirectory = BuildOptions.ConfDirectory
-        self.SpawnMode      = True
-        self.BuildReport    = BuildReport(BuildOptions.ReportFile, BuildOptions.ReportType)
-        self.AutoGenTime    = 0
-        self.MakeTime       = 0
-        self.GenFdsTime     = 0
-        self.MakeFileName   = ""
+        self.SpawnMode = True
+        self.BuildReport = BuildReport(BuildOptions.ReportFile, BuildOptions.ReportType)
+        self.AutoGenTime = 0
+        self.MakeTime = 0
+        self.GenFdsTime = 0
+        self.MakeFileName = ""
         TargetObj = TargetTxtDict()
-        ToolDefObj = ToolDefDict((os.path.join(os.getenv("WORKSPACE"),"Conf")))
+        ToolDefObj = ToolDefDict((os.path.join(os.getenv("WORKSPACE"), "Conf")))
         self.TargetTxt = TargetObj.Target
         self.ToolDef = ToolDefObj.ToolDef
-        GlobalData.BuildOptionPcd     = BuildOptions.OptionPcd if BuildOptions.OptionPcd else []
-        #Set global flag for build mode
+        GlobalData.BuildOptionPcd = BuildOptions.OptionPcd if BuildOptions.OptionPcd else []
+        # Set global flag for build mode
         GlobalData.gIgnoreSource = BuildOptions.IgnoreSources
         GlobalData.gUseHashCache = BuildOptions.UseHashCache
-        GlobalData.gBinCacheDest   = BuildOptions.BinCacheDest
+        GlobalData.gBinCacheDest = BuildOptions.BinCacheDest
         GlobalData.gBinCacheSource = BuildOptions.BinCacheSource
         GlobalData.gEnableGenfdsMultiThread = not BuildOptions.NoGenfdsMultiThread
         GlobalData.gDisableIncludePathCheck = BuildOptions.DisableIncludePathCheck
 
         if GlobalData.gBinCacheDest and not GlobalData.gUseHashCache:
-            EdkLogger.error("build", OPTION_NOT_SUPPORTED, ExtraData="--binary-destination must be used together with --hash.")
+            EdkLogger.error("build", OPTION_NOT_SUPPORTED,
+                            ExtraData="--binary-destination must be used together with --hash.")
 
         if GlobalData.gBinCacheSource and not GlobalData.gUseHashCache:
-            EdkLogger.error("build", OPTION_NOT_SUPPORTED, ExtraData="--binary-source must be used together with --hash.")
+            EdkLogger.error("build", OPTION_NOT_SUPPORTED,
+                            ExtraData="--binary-source must be used together with --hash.")
 
         if GlobalData.gBinCacheDest and GlobalData.gBinCacheSource:
-            EdkLogger.error("build", OPTION_NOT_SUPPORTED, ExtraData="--binary-destination can not be used together with --binary-source.")
+            EdkLogger.error("build", OPTION_NOT_SUPPORTED,
+                            ExtraData="--binary-destination can not be used together with --binary-source.")
 
         if GlobalData.gBinCacheSource:
             BinCacheSource = os.path.normpath(GlobalData.gBinCacheSource)
@@ -776,7 +802,8 @@ class Build():
             GlobalData.gBinCacheDest = BinCacheDest
         else:
             if GlobalData.gBinCacheDest is not None:
-                EdkLogger.error("build", OPTION_VALUE_INVALID, ExtraData="Invalid value of option --binary-destination.")
+                EdkLogger.error("build", OPTION_VALUE_INVALID,
+                                ExtraData="Invalid value of option --binary-destination.")
 
         GlobalData.gDatabasePath = os.path.normpath(os.path.join(GlobalData.gConfDirectory, GlobalData.gDatabasePath))
         if not os.path.exists(os.path.join(GlobalData.gConfDirectory, '.cache')):
@@ -786,7 +813,7 @@ class Build():
         self.Platform = None
         self.ToolChainFamily = None
         self.LoadFixAddress = 0
-        self.UniFlag        = BuildOptions.Flag
+        self.UniFlag = BuildOptions.Flag
         self.BuildModules = []
         self.HashSkipModules = []
         self.Db_Flag = False
@@ -801,11 +828,13 @@ class Build():
         EdkLogger.quiet("%-16s = %s" % ("WORKSPACE", os.environ["WORKSPACE"]))
         if "PACKAGES_PATH" in os.environ:
             # WORKSPACE env has been converted before. Print the same path style with WORKSPACE env.
-            EdkLogger.quiet("%-16s = %s" % ("PACKAGES_PATH", os.path.normcase(os.path.normpath(os.environ["PACKAGES_PATH"]))))
+            EdkLogger.quiet("%-16s = %s" %
+                            ("PACKAGES_PATH", os.path.normcase(os.path.normpath(os.environ["PACKAGES_PATH"]))))
         EdkLogger.quiet("%-16s = %s" % ("EDK_TOOLS_PATH", os.environ["EDK_TOOLS_PATH"]))
         if "EDK_TOOLS_BIN" in os.environ:
             # Print the same path style with WORKSPACE env.
-            EdkLogger.quiet("%-16s = %s" % ("EDK_TOOLS_BIN", os.path.normcase(os.path.normpath(os.environ["EDK_TOOLS_BIN"]))))
+            EdkLogger.quiet("%-16s = %s" %
+                            ("EDK_TOOLS_BIN", os.path.normcase(os.path.normpath(os.environ["EDK_TOOLS_BIN"]))))
         EdkLogger.quiet("%-16s = %s" % ("CONF_PATH", GlobalData.gConfDirectory))
         if "PYTHON3_ENABLE" in os.environ:
             PYTHON3_ENABLE = os.environ["PYTHON3_ENABLE"]
@@ -833,7 +862,7 @@ class Build():
         EdkLogger.info("")
         os.chdir(self.WorkspaceDir)
         self.log_q = log_q
-        GlobalData.file_lock =  mp.Lock()
+        GlobalData.file_lock = mp.Lock()
         # Init cache data for local only
         GlobalData.gPackageHashFile = dict()
         GlobalData.gModulePreMakeCacheStatus = dict()
@@ -845,18 +874,19 @@ class Build():
         GlobalData.gModuleAllCacheStatus = set()
         GlobalData.gModuleCacheHit = set()
 
-    def StartAutoGen(self,mqueue, DataPipe,SkipAutoGen,PcdMaList,cqueue):
+    def StartAutoGen(self, mqueue, DataPipe, SkipAutoGen, PcdMaList, cqueue):
         try:
             if SkipAutoGen:
-                return True,0
+                return True, 0
             feedback_q = mp.Queue()
             error_event = mp.Event()
             FfsCmd = DataPipe.Get("FfsCommand")
             if FfsCmd is None:
                 FfsCmd = {}
             GlobalData.FfsCmd = FfsCmd
-            auto_workers = [AutoGenWorkerInProcess(mqueue,DataPipe.dump_file,feedback_q,GlobalData.file_lock,cqueue,self.log_q,error_event) for _ in range(self.ThreadNumber)]
-            self.AutoGenMgr = AutoGenManager(auto_workers,feedback_q,error_event)
+            auto_workers = [AutoGenWorkerInProcess(
+                mqueue, DataPipe.dump_file, feedback_q, GlobalData.file_lock, cqueue, self.log_q, error_event) for _ in range(self.ThreadNumber)]
+            self.AutoGenMgr = AutoGenManager(auto_workers, feedback_q, error_event)
             self.AutoGenMgr.start()
             for w in auto_workers:
                 w.start()
@@ -871,7 +901,8 @@ class Build():
                         cqueue.put((PcdMa.MetaFile.Path, PcdMa.Arch, "PreMakeCache", False))
 
                     PcdMa.CreateCodeFile(False)
-                    PcdMa.CreateMakeFile(False,GenFfsList = DataPipe.Get("FfsCommand").get((PcdMa.MetaFile.Path, PcdMa.Arch),[]))
+                    PcdMa.CreateMakeFile(False, GenFfsList=DataPipe.Get(
+                        "FfsCommand").get((PcdMa.MetaFile.Path, PcdMa.Arch), []))
                     PcdMa.CreateAsBuiltInf()
                     # Force cache miss for PCD driver
                     if GlobalData.gBinCacheSource and self.Target in [None, "", "all"]:
@@ -888,19 +919,19 @@ class Build():
         except:
             return False, UNKNOWN_ERROR
 
-    ## Add TOOLCHAIN and FAMILY declared in DSC [BuildOptions] to ToolsDefTxtDatabase.
+    # Add TOOLCHAIN and FAMILY declared in DSC [BuildOptions] to ToolsDefTxtDatabase.
     #
     # Loop through the set of build targets, tool chains, and archs provided on either
     # the command line or in target.txt to discover FAMILY and TOOLCHAIN delclarations
     # in [BuildOptions] sections that may be within !if expressions that may use
     # $(TARGET), $(TOOLCHAIN), $(TOOLCHAIN_TAG), or $(ARCH) operands.
     #
-    def GetToolChainAndFamilyFromDsc (self, File):
+    def GetToolChainAndFamilyFromDsc(self, File):
         SavedGlobalDefines = GlobalData.gGlobalDefines.copy()
         for BuildTarget in self.BuildTargetList:
             GlobalData.gGlobalDefines['TARGET'] = BuildTarget
             for BuildToolChain in self.ToolChainList:
-                GlobalData.gGlobalDefines['TOOLCHAIN']      = BuildToolChain
+                GlobalData.gGlobalDefines['TOOLCHAIN'] = BuildToolChain
                 GlobalData.gGlobalDefines['TOOL_CHAIN_TAG'] = BuildToolChain
                 for BuildArch in self.ArchList:
                     GlobalData.gGlobalDefines['ARCH'] = BuildArch
@@ -931,7 +962,7 @@ class Build():
                             self.ToolDef.ToolsDefTxtDatabase[TAB_TOD_DEFINES_TOOL_CHAIN_TAG].append(ToolChain)
         GlobalData.gGlobalDefines = SavedGlobalDefines
 
-    ## Load configuration
+    # Load configuration
     #
     #   This method will parse target.txt and get the build configurations.
     #
@@ -950,7 +981,8 @@ class Build():
         if not self.ToolChainList:
             self.ToolChainList = self.TargetTxt.TargetTxtDictionary[TAB_TAT_DEFINES_TOOL_CHAIN_TAG]
             if self.ToolChainList is None or len(self.ToolChainList) == 0:
-                EdkLogger.error("build", RESOURCE_NOT_AVAILABLE, ExtraData="No toolchain given. Don't know how to build.\n")
+                EdkLogger.error("build", RESOURCE_NOT_AVAILABLE,
+                                ExtraData="No toolchain given. Don't know how to build.\n")
 
         if not self.PlatformFile:
             PlatformFile = self.TargetTxt.TargetTxtDictionary[TAB_TAT_DEFINES_ACTIVE_PLATFORM]
@@ -970,7 +1002,7 @@ class Build():
 
             self.PlatformFile = PathClass(NormFile(PlatformFile, self.WorkspaceDir), self.WorkspaceDir)
 
-        self.GetToolChainAndFamilyFromDsc (self.PlatformFile)
+        self.GetToolChainAndFamilyFromDsc(self.PlatformFile)
 
         # check if the tool chains are defined or not
         NewToolChainList = []
@@ -997,12 +1029,13 @@ class Build():
                 ToolChainFamily.append(ToolDefinition[TAB_TOD_DEFINES_FAMILY][Tool])
         self.ToolChainFamily = ToolChainFamily
 
-        self.ThreadNumber   = ThreadNum()
-    ## Initialize build configuration
+        self.ThreadNumber = ThreadNum()
+    # Initialize build configuration
     #
     #   This method will parse DSC file and merge the configurations from
     #   command line and target.txt, then get the final build configurations.
     #
+
     def InitBuild(self):
         # parse target.txt, tools_def.txt, and platform file
         self.LoadConfiguration()
@@ -1011,7 +1044,6 @@ class Build():
         ErrorCode, ErrorInfo = self.PlatformFile.Validate(".dsc", False)
         if ErrorCode != 0:
             EdkLogger.error("build", ErrorCode, ExtraData=ErrorInfo)
-
 
     def InitPreBuild(self):
         self.LoadConfiguration()
@@ -1028,7 +1060,7 @@ class Build():
         if self.ToolChainFamily:
             GlobalData.gGlobalDefines['FAMILY'] = self.ToolChainFamily[0]
         if 'PREBUILD' in GlobalData.gCommandLineDefines:
-            self.Prebuild   = GlobalData.gCommandLineDefines.get('PREBUILD')
+            self.Prebuild = GlobalData.gCommandLineDefines.get('PREBUILD')
         else:
             self.Db_Flag = True
             Platform = self.Db.MapPlatform(str(self.PlatformFile))
@@ -1045,7 +1077,7 @@ class Build():
                 #
                 # Do not modify Arg if it looks like a flag or an absolute file path
                 #
-                if Arg.startswith('-')  or os.path.isabs(Arg):
+                if Arg.startswith('-') or os.path.isabs(Arg):
                     PrebuildList.append(Arg)
                     continue
                 #
@@ -1063,8 +1095,9 @@ class Build():
                 if os.path.isfile(Temp):
                     Arg = Temp
                 PrebuildList.append(Arg)
-            self.Prebuild       = ' '.join(PrebuildList)
-            self.Prebuild += self.PassCommandOption(self.BuildTargetList, self.ArchList, self.ToolChainList, self.PlatformFile, self.Target)
+            self.Prebuild = ' '.join(PrebuildList)
+            self.Prebuild += self.PassCommandOption(self.BuildTargetList,
+                                                    self.ArchList, self.ToolChainList, self.PlatformFile, self.Target)
 
     def InitPostBuild(self):
         if 'POSTBUILD' in GlobalData.gCommandLineDefines:
@@ -1084,7 +1117,7 @@ class Build():
                 #
                 # Do not modify Arg if it looks like a flag or an absolute file path
                 #
-                if Arg.startswith('-')  or os.path.isabs(Arg):
+                if Arg.startswith('-') or os.path.isabs(Arg):
                     PostbuildList.append(Arg)
                     continue
                 #
@@ -1102,8 +1135,9 @@ class Build():
                 if os.path.isfile(Temp):
                     Arg = Temp
                 PostbuildList.append(Arg)
-            self.Postbuild       = ' '.join(PostbuildList)
-            self.Postbuild += self.PassCommandOption(self.BuildTargetList, self.ArchList, self.ToolChainList, self.PlatformFile, self.Target)
+            self.Postbuild = ' '.join(PostbuildList)
+            self.Postbuild += self.PassCommandOption(self.BuildTargetList,
+                                                     self.ArchList, self.ToolChainList, self.PlatformFile, self.Target)
 
     def PassCommandOption(self, BuildTarget, TargetArch, ToolChain, PlatformFile, Target):
         BuildStr = ''
@@ -1114,13 +1148,13 @@ class Build():
         ToolChainFlag = False
         PlatformFileFlag = False
 
-        if GlobalData.gOptions and not GlobalData.gOptions.BuildTarget:
+        if GlobalData.gArguments and not GlobalData.gArguments.BuildTarget:
             TargetFlag = True
-        if GlobalData.gOptions and not GlobalData.gOptions.TargetArch:
+        if GlobalData.gArguments and not GlobalData.gArguments.TargetArch:
             ArchFlag = True
-        if GlobalData.gOptions and not GlobalData.gOptions.ToolChain:
+        if GlobalData.gArguments and not GlobalData.gArguments.ToolChain:
             ToolChainFlag = True
-        if GlobalData.gOptions and not GlobalData.gOptions.PlatformFile:
+        if GlobalData.gArguments and not GlobalData.gArguments.PlatformFile:
             PlatformFileFlag = True
 
         if TargetFlag and BuildTarget:
@@ -1191,14 +1225,14 @@ class Build():
                 StdOutThread.join()
             if Process.stderr:
                 StdErrThread.join()
-            if Process.returncode != 0 :
+            if Process.returncode != 0:
                 EdkLogger.error("Prebuild", PREBUILD_ERROR, 'Prebuild process is not success!')
 
             if os.path.exists(PrebuildEnvFile):
                 f = open(PrebuildEnvFile)
                 envs = f.readlines()
                 f.close()
-                envs = [l.split("=", 1) for l in envs ]
+                envs = [l.split("=", 1) for l in envs]
                 envs = [[I.strip() for I in item] for item in envs if len(item) == 2]
                 os.environ.update(dict(envs))
             EdkLogger.info("\n- Prebuild Done -\n")
@@ -1231,11 +1265,11 @@ class Build():
                 StdOutThread.join()
             if Process.stderr:
                 StdErrThread.join()
-            if Process.returncode != 0 :
+            if Process.returncode != 0:
                 EdkLogger.error("Postbuild", POSTBUILD_ERROR, 'Postbuild process is not success!')
             EdkLogger.info("\n- Postbuild Done -\n")
 
-    ## Build a module or platform
+    # Build a module or platform
     #
     # Create autogen code and makefile for a module or platform, and the launch
     # "make" command to build it
@@ -1262,20 +1296,23 @@ class Build():
             mqueue = mp.Queue()
             for m in AutoGenObject.GetAllModuleInfo:
                 mqueue.put(m)
-            mqueue.put((None,None,None,None,None,None,None))
+            mqueue.put((None, None, None, None, None, None, None))
             AutoGenObject.DataPipe.DataContainer = {"CommandTarget": self.Target}
             AutoGenObject.DataPipe.DataContainer = {"Workspace_timestamp": AutoGenObject.Workspace._SrcTimeStamp}
             AutoGenObject.CreateLibModuelDirs()
-            AutoGenObject.DataPipe.DataContainer = {"LibraryBuildDirectoryList":AutoGenObject.LibraryBuildDirectoryList}
-            AutoGenObject.DataPipe.DataContainer = {"ModuleBuildDirectoryList":AutoGenObject.ModuleBuildDirectoryList}
+            AutoGenObject.DataPipe.DataContainer = {
+                "LibraryBuildDirectoryList": AutoGenObject.LibraryBuildDirectoryList}
+            AutoGenObject.DataPipe.DataContainer = {"ModuleBuildDirectoryList": AutoGenObject.ModuleBuildDirectoryList}
             AutoGenObject.DataPipe.DataContainer = {"FdsCommandDict": AutoGenObject.Workspace.GenFdsCommandDict}
             self.Progress.Start("Generating makefile and code")
-            data_pipe_file = os.path.join(AutoGenObject.BuildDir, "GlobalVar_%s_%s.bin" % (str(AutoGenObject.Guid),AutoGenObject.Arch))
+            data_pipe_file = os.path.join(AutoGenObject.BuildDir, "GlobalVar_%s_%s.bin" %
+                                          (str(AutoGenObject.Guid), AutoGenObject.Arch))
             AutoGenObject.DataPipe.dump(data_pipe_file)
             cqueue = mp.Queue()
-            autogen_rt,errorcode = self.StartAutoGen(mqueue, AutoGenObject.DataPipe, self.SkipAutoGen, PcdMaList, cqueue)
-            AutoGenIdFile = os.path.join(GlobalData.gConfDirectory,".AutoGenIdFile.txt")
-            with open(AutoGenIdFile,"w") as fw:
+            autogen_rt, errorcode = self.StartAutoGen(
+                mqueue, AutoGenObject.DataPipe, self.SkipAutoGen, PcdMaList, cqueue)
+            AutoGenIdFile = os.path.join(GlobalData.gConfDirectory, ".AutoGenIdFile.txt")
+            with open(AutoGenIdFile, "w") as fw:
                 fw.write("Arch=%s\n" % "|".join((AutoGenObject.Workspace.ArchList)))
                 fw.write("BuildDir=%s\n" % AutoGenObject.Workspace.BuildDir)
                 fw.write("PlatformGuid=%s\n" % str(AutoGenObject.Guid))
@@ -1299,7 +1336,7 @@ class Build():
             EdkLogger.error("build", OPTION_MISSING,
                             "No build command found for this module. "
                             "Please check your setting of %s_%s_%s_MAKE_PATH in Conf/tools_def.txt file." %
-                                (AutoGenObject.BuildTarget, AutoGenObject.ToolChain, AutoGenObject.Arch),
+                            (AutoGenObject.BuildTarget, AutoGenObject.ToolChain, AutoGenObject.Arch),
                             ExtraData=str(AutoGenObject))
 
         # run
@@ -1327,10 +1364,11 @@ class Build():
             DirList = []
             for Lib in AutoGenObject.LibraryAutoGenList:
                 if not Lib.IsBinaryModule:
-                    DirList.append((os.path.join(AutoGenObject.BuildDir, Lib.BuildDir),Lib))
+                    DirList.append((os.path.join(AutoGenObject.BuildDir, Lib.BuildDir), Lib))
             for Lib, LibAutoGen in DirList:
-                NewBuildCommand = BuildCommand + ['-f', os.path.normpath(os.path.join(Lib, self.MakeFileName)), 'pbuild']
-                LaunchCommand(NewBuildCommand, AutoGenObject.MakeFileDir,LibAutoGen)
+                NewBuildCommand = BuildCommand + \
+                    ['-f', os.path.normpath(os.path.join(Lib, self.MakeFileName)), 'pbuild']
+                LaunchCommand(NewBuildCommand, AutoGenObject.MakeFileDir, LibAutoGen)
             return True
 
         # build module
@@ -1338,18 +1376,20 @@ class Build():
             DirList = []
             for Lib in AutoGenObject.LibraryAutoGenList:
                 if not Lib.IsBinaryModule:
-                    DirList.append((os.path.join(AutoGenObject.BuildDir, Lib.BuildDir),Lib))
+                    DirList.append((os.path.join(AutoGenObject.BuildDir, Lib.BuildDir), Lib))
             for Lib, LibAutoGen in DirList:
-                NewBuildCommand = BuildCommand + ['-f', os.path.normpath(os.path.join(Lib, self.MakeFileName)), 'pbuild']
-                LaunchCommand(NewBuildCommand, AutoGenObject.MakeFileDir,LibAutoGen)
+                NewBuildCommand = BuildCommand + \
+                    ['-f', os.path.normpath(os.path.join(Lib, self.MakeFileName)), 'pbuild']
+                LaunchCommand(NewBuildCommand, AutoGenObject.MakeFileDir, LibAutoGen)
 
             DirList = []
             for ModuleAutoGen in AutoGenObject.ModuleAutoGenList:
                 if not ModuleAutoGen.IsBinaryModule:
-                    DirList.append((os.path.join(AutoGenObject.BuildDir, ModuleAutoGen.BuildDir),ModuleAutoGen))
-            for Mod,ModAutoGen in DirList:
-                NewBuildCommand = BuildCommand + ['-f', os.path.normpath(os.path.join(Mod, self.MakeFileName)), 'pbuild']
-                LaunchCommand(NewBuildCommand, AutoGenObject.MakeFileDir,ModAutoGen)
+                    DirList.append((os.path.join(AutoGenObject.BuildDir, ModuleAutoGen.BuildDir), ModuleAutoGen))
+            for Mod, ModAutoGen in DirList:
+                NewBuildCommand = BuildCommand + \
+                    ['-f', os.path.normpath(os.path.join(Mod, self.MakeFileName)), 'pbuild']
+                LaunchCommand(NewBuildCommand, AutoGenObject.MakeFileDir, ModAutoGen)
             self.CreateAsBuiltInf()
             if GlobalData.gBinCacheDest:
                 self.GenDestCache()
@@ -1386,13 +1426,13 @@ class Build():
         # cleanall
         if Target == 'cleanall':
             try:
-                #os.rmdir(AutoGenObject.BuildDir)
+                # os.rmdir(AutoGenObject.BuildDir)
                 RemoveDirectory(AutoGenObject.BuildDir, True)
             except WindowsError as X:
                 EdkLogger.error("build", FILE_DELETE_FAILURE, ExtraData=str(X))
         return True
 
-    ## Build a module or platform
+    # Build a module or platform
     #
     # Create autogen code and makefile for a module or platform, and the launch
     # "make" command to build it
@@ -1425,7 +1465,7 @@ class Build():
             if not self.SkipAutoGen or Target == 'genmake':
                 self.Progress.Start("Generating makefile")
                 AutoGenObject.CreateMakeFile(CreateDepsMakeFile)
-                #AutoGenObject.CreateAsBuiltInf()
+                # AutoGenObject.CreateAsBuiltInf()
                 self.Progress.Stop("done!")
             if Target == "genmake":
                 return True
@@ -1442,7 +1482,7 @@ class Build():
             EdkLogger.error("build", OPTION_MISSING,
                             "No build command found for this module. "
                             "Please check your setting of %s_%s_%s_MAKE_PATH in Conf/tools_def.txt file." %
-                                (AutoGenObject.BuildTarget, AutoGenObject.ToolChain, AutoGenObject.Arch),
+                            (AutoGenObject.BuildTarget, AutoGenObject.ToolChain, AutoGenObject.Arch),
                             ExtraData=str(AutoGenObject))
 
         # build modules
@@ -1479,29 +1519,28 @@ class Build():
 
         # not build modules
 
-
         # cleanall
         if Target == 'cleanall':
             try:
-                #os.rmdir(AutoGenObject.BuildDir)
+                # os.rmdir(AutoGenObject.BuildDir)
                 RemoveDirectory(AutoGenObject.BuildDir, True)
             except WindowsError as X:
                 EdkLogger.error("build", FILE_DELETE_FAILURE, ExtraData=str(X))
         return True
 
-    ## Rebase module image and Get function address for the input module list.
+    # Rebase module image and Get function address for the input module list.
     #
-    def _RebaseModule (self, MapBuffer, BaseAddress, ModuleList, AddrIsOffset = True, ModeIsSmm = False):
+    def _RebaseModule(self, MapBuffer, BaseAddress, ModuleList, AddrIsOffset=True, ModeIsSmm=False):
         if ModeIsSmm:
             AddrIsOffset = False
         for InfFile in ModuleList:
-            sys.stdout.write (".")
+            sys.stdout.write(".")
             sys.stdout.flush()
             ModuleInfo = ModuleList[InfFile]
             ModuleName = ModuleInfo.BaseName
             ModuleOutputImage = ModuleInfo.Image.FileName
-            ModuleDebugImage  = os.path.join(ModuleInfo.DebugDir, ModuleInfo.BaseName + '.efi')
-            ## for SMM module in SMRAM, the SMRAM will be allocated from base to top.
+            ModuleDebugImage = os.path.join(ModuleInfo.DebugDir, ModuleInfo.BaseName + '.efi')
+            # for SMM module in SMRAM, the SMRAM will be allocated from base to top.
             if not ModeIsSmm:
                 BaseAddress = BaseAddress - ModuleInfo.Image.Size
                 #
@@ -1524,32 +1563,35 @@ class Build():
                 OrigImageBaseAddress = 0
                 ImageMap = open(ImageMapTable, 'r')
                 for LinStr in ImageMap:
-                    if len (LinStr.strip()) == 0:
+                    if len(LinStr.strip()) == 0:
                         continue
                     #
                     # Get the preferred address set on link time.
                     #
-                    if LinStr.find ('Preferred load address is') != -1:
+                    if LinStr.find('Preferred load address is') != -1:
                         StrList = LinStr.split()
-                        OrigImageBaseAddress = int (StrList[len(StrList) - 1], 16)
+                        OrigImageBaseAddress = int(StrList[len(StrList) - 1], 16)
 
                     StrList = LinStr.split()
-                    if len (StrList) > 4:
+                    if len(StrList) > 4:
                         if StrList[3] == 'f' or StrList[3] == 'F':
                             Name = StrList[1]
-                            RelativeAddress = int (StrList[2], 16) - OrigImageBaseAddress
-                            FunctionList.append ((Name, RelativeAddress))
+                            RelativeAddress = int(StrList[2], 16) - OrigImageBaseAddress
+                            FunctionList.append((Name, RelativeAddress))
 
                 ImageMap.close()
             #
             # Add general information.
             #
             if ModeIsSmm:
-                MapBuffer.append('\n\n%s (Fixed SMRAM Offset,   BaseAddress=0x%010X,  EntryPoint=0x%010X)\n' % (ModuleName, BaseAddress, BaseAddress + ModuleInfo.Image.EntryPoint))
+                MapBuffer.append('\n\n%s (Fixed SMRAM Offset,   BaseAddress=0x%010X,  EntryPoint=0x%010X)\n' %
+                                 (ModuleName, BaseAddress, BaseAddress + ModuleInfo.Image.EntryPoint))
             elif AddrIsOffset:
-                MapBuffer.append('\n\n%s (Fixed Memory Offset,  BaseAddress=-0x%010X, EntryPoint=-0x%010X)\n' % (ModuleName, 0 - BaseAddress, 0 - (BaseAddress + ModuleInfo.Image.EntryPoint)))
+                MapBuffer.append('\n\n%s (Fixed Memory Offset,  BaseAddress=-0x%010X, EntryPoint=-0x%010X)\n' %
+                                 (ModuleName, 0 - BaseAddress, 0 - (BaseAddress + ModuleInfo.Image.EntryPoint)))
             else:
-                MapBuffer.append('\n\n%s (Fixed Memory Address, BaseAddress=0x%010X,  EntryPoint=0x%010X)\n' % (ModuleName, BaseAddress, BaseAddress + ModuleInfo.Image.EntryPoint))
+                MapBuffer.append('\n\n%s (Fixed Memory Address, BaseAddress=0x%010X,  EntryPoint=0x%010X)\n' %
+                                 (ModuleName, BaseAddress, BaseAddress + ModuleInfo.Image.EntryPoint))
             #
             # Add guid and general seciton section.
             #
@@ -1561,9 +1603,11 @@ class Build():
                 elif SectionHeader[0] in ['.data', '.sdata']:
                     DataSectionAddress = SectionHeader[1]
             if AddrIsOffset:
-                MapBuffer.append('(GUID=%s, .textbaseaddress=-0x%010X, .databaseaddress=-0x%010X)\n' % (ModuleInfo.Guid, 0 - (BaseAddress + TextSectionAddress), 0 - (BaseAddress + DataSectionAddress)))
+                MapBuffer.append('(GUID=%s, .textbaseaddress=-0x%010X, .databaseaddress=-0x%010X)\n' %
+                                 (ModuleInfo.Guid, 0 - (BaseAddress + TextSectionAddress), 0 - (BaseAddress + DataSectionAddress)))
             else:
-                MapBuffer.append('(GUID=%s, .textbaseaddress=0x%010X, .databaseaddress=0x%010X)\n' % (ModuleInfo.Guid, BaseAddress + TextSectionAddress, BaseAddress + DataSectionAddress))
+                MapBuffer.append('(GUID=%s, .textbaseaddress=0x%010X, .databaseaddress=0x%010X)\n' %
+                                 (ModuleInfo.Guid, BaseAddress + TextSectionAddress, BaseAddress + DataSectionAddress))
             #
             # Add debug image full path.
             #
@@ -1584,9 +1628,9 @@ class Build():
             if ModeIsSmm:
                 BaseAddress = BaseAddress + ModuleInfo.Image.Size
 
-    ## Collect MAP information of all FVs
+    # Collect MAP information of all FVs
     #
-    def _CollectFvMapBuffer (self, MapBuffer, Wa, ModuleList):
+    def _CollectFvMapBuffer(self, MapBuffer, Wa, ModuleList):
         if self.Fdf:
             # First get the XIP base address for FV map file.
             GuidPattern = re.compile("[-a-fA-F0-9]+")
@@ -1596,7 +1640,7 @@ class Build():
                 if not os.path.exists(FvMapBuffer):
                     continue
                 FvMap = open(FvMapBuffer, 'r')
-                #skip FV size information
+                # skip FV size information
                 FvMap.readline()
                 FvMap.readline()
                 FvMap.readline()
@@ -1618,28 +1662,30 @@ class Build():
                     if MatchGuid is not None:
                         GuidString = MatchGuid.group().split("=")[1]
                         if GuidString.upper() in ModuleList:
-                            MapBuffer.append('(IMAGE=%s)\n' % (os.path.join(ModuleList[GuidString.upper()].DebugDir, ModuleList[GuidString.upper()].Name + '.efi')))
+                            MapBuffer.append('(IMAGE=%s)\n' % (os.path.join(
+                                ModuleList[GuidString.upper()].DebugDir, ModuleList[GuidString.upper()].Name + '.efi')))
 
                 FvMap.close()
 
-    ## Collect MAP information of all modules
+    # Collect MAP information of all modules
     #
-    def _CollectModuleMapBuffer (self, MapBuffer, ModuleList):
-        sys.stdout.write ("Generate Load Module At Fix Address Map")
+    def _CollectModuleMapBuffer(self, MapBuffer, ModuleList):
+        sys.stdout.write("Generate Load Module At Fix Address Map")
         sys.stdout.flush()
         PatchEfiImageList = []
-        PeiModuleList  = {}
-        BtModuleList   = {}
-        RtModuleList   = {}
-        SmmModuleList  = {}
+        PeiModuleList = {}
+        BtModuleList = {}
+        RtModuleList = {}
+        SmmModuleList = {}
         PeiSize = 0
-        BtSize  = 0
-        RtSize  = 0
+        BtSize = 0
+        RtSize = 0
         # reserve 4K size in SMRAM to make SMM module address not from 0.
         SmmSize = 0x1000
         for ModuleGuid in ModuleList:
             Module = ModuleList[ModuleGuid]
-            GlobalData.gProcessingFile = "%s [%s, %s, %s]" % (Module.MetaFile, Module.Arch, Module.ToolChain, Module.BuildTarget)
+            GlobalData.gProcessingFile = "%s [%s, %s, %s]" % (
+                Module.MetaFile, Module.Arch, Module.ToolChain, Module.BuildTarget)
 
             OutputImageFile = ''
             for ResultFile in Module.CodaTargetList:
@@ -1648,10 +1694,11 @@ class Build():
                     # module list for PEI, DXE, RUNTIME and SMM
                     #
                     OutputImageFile = os.path.join(Module.OutputDir, Module.Name + '.efi')
-                    ImageClass = PeImageClass (OutputImageFile)
+                    ImageClass = PeImageClass(OutputImageFile)
                     if not ImageClass.IsValid:
                         EdkLogger.error("build", FILE_PARSE_FAILURE, ExtraData=ImageClass.ErrorInfo)
-                    ImageInfo = PeImageInfo(Module.Name, Module.Guid, Module.Arch, Module.OutputDir, Module.DebugDir, ImageClass)
+                    ImageInfo = PeImageInfo(Module.Name, Module.Guid, Module.Arch,
+                                            Module.OutputDir, Module.DebugDir, ImageClass)
                     if Module.ModuleType in [SUP_MODULE_PEI_CORE, SUP_MODULE_PEIM, EDK_COMPONENT_TYPE_COMBINED_PEIM_DRIVER, EDK_COMPONENT_TYPE_PIC_PEIM, EDK_COMPONENT_TYPE_RELOCATABLE_PEIM, SUP_MODULE_DXE_CORE]:
                         PeiModuleList[Module.MetaFile] = ImageInfo
                         PeiSize += ImageInfo.Image.Size
@@ -1693,7 +1740,7 @@ class Build():
                 # Module includes the patchable load fix address PCDs.
                 # It will be fixed up later.
                 #
-                PatchEfiImageList.append (OutputImageFile)
+                PatchEfiImageList.append(OutputImageFile)
 
         #
         # Get Top Memory address
@@ -1724,37 +1771,41 @@ class Build():
             for PcdInfo in PcdTable:
                 ReturnValue = 0
                 if PcdInfo[0] == TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_PEI_PAGE_SIZE:
-                    ReturnValue, ErrorInfo = PatchBinaryFile (EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_PEI_PAGE_SIZE_DATA_TYPE, str (PeiSize // 0x1000))
+                    ReturnValue, ErrorInfo = PatchBinaryFile(
+                        EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_PEI_PAGE_SIZE_DATA_TYPE, str(PeiSize // 0x1000))
                 elif PcdInfo[0] == TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_DXE_PAGE_SIZE:
-                    ReturnValue, ErrorInfo = PatchBinaryFile (EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_DXE_PAGE_SIZE_DATA_TYPE, str (BtSize // 0x1000))
+                    ReturnValue, ErrorInfo = PatchBinaryFile(
+                        EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_DXE_PAGE_SIZE_DATA_TYPE, str(BtSize // 0x1000))
                 elif PcdInfo[0] == TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_RUNTIME_PAGE_SIZE:
-                    ReturnValue, ErrorInfo = PatchBinaryFile (EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_RUNTIME_PAGE_SIZE_DATA_TYPE, str (RtSize // 0x1000))
-                elif PcdInfo[0] == TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_SMM_PAGE_SIZE and len (SmmModuleList) > 0:
-                    ReturnValue, ErrorInfo = PatchBinaryFile (EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_SMM_PAGE_SIZE_DATA_TYPE, str (SmmSize // 0x1000))
+                    ReturnValue, ErrorInfo = PatchBinaryFile(
+                        EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_RUNTIME_PAGE_SIZE_DATA_TYPE, str(RtSize // 0x1000))
+                elif PcdInfo[0] == TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_SMM_PAGE_SIZE and len(SmmModuleList) > 0:
+                    ReturnValue, ErrorInfo = PatchBinaryFile(
+                        EfiImage, PcdInfo[1], TAB_PCDS_PATCHABLE_LOAD_FIX_ADDRESS_SMM_PAGE_SIZE_DATA_TYPE, str(SmmSize // 0x1000))
                 if ReturnValue != 0:
                     EdkLogger.error("build", PARAMETER_INVALID, "Patch PCD value failed", ExtraData=ErrorInfo)
 
         MapBuffer.append('PEI_CODE_PAGE_NUMBER      = 0x%x\n' % (PeiSize // 0x1000))
         MapBuffer.append('BOOT_CODE_PAGE_NUMBER     = 0x%x\n' % (BtSize // 0x1000))
         MapBuffer.append('RUNTIME_CODE_PAGE_NUMBER  = 0x%x\n' % (RtSize // 0x1000))
-        if len (SmmModuleList) > 0:
+        if len(SmmModuleList) > 0:
             MapBuffer.append('SMM_CODE_PAGE_NUMBER      = 0x%x\n' % (SmmSize // 0x1000))
 
         PeiBaseAddr = TopMemoryAddress - RtSize - BtSize
-        BtBaseAddr  = TopMemoryAddress - RtSize
-        RtBaseAddr  = TopMemoryAddress - ReservedRuntimeMemorySize
+        BtBaseAddr = TopMemoryAddress - RtSize
+        RtBaseAddr = TopMemoryAddress - ReservedRuntimeMemorySize
 
-        self._RebaseModule (MapBuffer, PeiBaseAddr, PeiModuleList, TopMemoryAddress == 0)
-        self._RebaseModule (MapBuffer, BtBaseAddr, BtModuleList, TopMemoryAddress == 0)
-        self._RebaseModule (MapBuffer, RtBaseAddr, RtModuleList, TopMemoryAddress == 0)
-        self._RebaseModule (MapBuffer, 0x1000, SmmModuleList, AddrIsOffset=False, ModeIsSmm=True)
+        self._RebaseModule(MapBuffer, PeiBaseAddr, PeiModuleList, TopMemoryAddress == 0)
+        self._RebaseModule(MapBuffer, BtBaseAddr, BtModuleList, TopMemoryAddress == 0)
+        self._RebaseModule(MapBuffer, RtBaseAddr, RtModuleList, TopMemoryAddress == 0)
+        self._RebaseModule(MapBuffer, 0x1000, SmmModuleList, AddrIsOffset=False, ModeIsSmm=True)
         MapBuffer.append('\n\n')
-        sys.stdout.write ("\n")
+        sys.stdout.write("\n")
         sys.stdout.flush()
 
-    ## Save platform Map file
+    # Save platform Map file
     #
-    def _SaveMapFile (self, MapBuffer, Wa):
+    def _SaveMapFile(self, MapBuffer, Wa):
         #
         # Map file path is got.
         #
@@ -1764,10 +1815,10 @@ class Build():
         #
         SaveFileOnChange(MapFilePath, ''.join(MapBuffer), False)
         if self.LoadFixAddress != 0:
-            sys.stdout.write ("\nLoad Module At Fix Address Map file can be found at %s\n" % (MapFilePath))
+            sys.stdout.write("\nLoad Module At Fix Address Map file can be found at %s\n" % (MapFilePath))
         sys.stdout.flush()
 
-    ## Build active platform for different build targets and different tool chains
+    # Build active platform for different build targets and different tool chains
     #
     def _BuildPlatform(self):
         SaveFileOnChange(self.PlatformBuildPath, '# DO NOT EDIT \n# FILE auto-generated\n', False)
@@ -1780,22 +1831,22 @@ class Build():
                 GlobalData.gGlobalDefines['FAMILY'] = self.ToolChainFamily[index]
                 index += 1
                 Wa = WorkspaceAutoGen(
-                        self.WorkspaceDir,
-                        self.PlatformFile,
-                        BuildTarget,
-                        ToolChain,
-                        self.ArchList,
-                        self.BuildDatabase,
-                        self.TargetTxt,
-                        self.ToolDef,
-                        self.Fdf,
-                        self.FdList,
-                        self.FvList,
-                        self.CapList,
-                        self.SkuId,
-                        self.UniFlag,
-                        self.Progress
-                        )
+                    self.WorkspaceDir,
+                    self.PlatformFile,
+                    BuildTarget,
+                    ToolChain,
+                    self.ArchList,
+                    self.BuildDatabase,
+                    self.TargetTxt,
+                    self.ToolDef,
+                    self.Fdf,
+                    self.FdList,
+                    self.FvList,
+                    self.CapList,
+                    self.SkuId,
+                    self.UniFlag,
+                    self.Progress
+                )
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 self.BuildReport.AddPlatformReport(Wa)
@@ -1807,12 +1858,12 @@ class Build():
                     CmdListDict = self._GenFfsCmd(Wa.ArchList)
 
                 for Arch in Wa.ArchList:
-                    PcdMaList    = []
+                    PcdMaList = []
                     GlobalData.gGlobalDefines['ARCH'] = Arch
                     Pa = PlatformAutoGen(Wa, self.PlatformFile, BuildTarget, ToolChain, Arch)
                     for Module in Pa.Platform.Modules:
                         # Get ModuleAutoGen object to generate C code file and makefile
-                        Ma = ModuleAutoGen(Wa, Module, BuildTarget, ToolChain, Arch, self.PlatformFile,Pa.DataPipe)
+                        Ma = ModuleAutoGen(Wa, Module, BuildTarget, ToolChain, Arch, self.PlatformFile, Pa.DataPipe)
                         if Ma is None:
                             continue
                         if Ma.PcdIsDriver:
@@ -1820,9 +1871,9 @@ class Build():
                             Ma.Workspace = Wa
                             PcdMaList.append(Ma)
                         self.BuildModules.append(Ma)
-                    Pa.DataPipe.DataContainer = {"FfsCommand":CmdListDict}
+                    Pa.DataPipe.DataContainer = {"FfsCommand": CmdListDict}
                     Pa.DataPipe.DataContainer = {"Workspace_timestamp": Wa._SrcTimeStamp}
-                    self._BuildPa(self.Target, Pa, FfsCommand=CmdListDict,PcdMaList=PcdMaList)
+                    self._BuildPa(self.Target, Pa, FfsCommand=CmdListDict, PcdMaList=PcdMaList)
 
                 # Create MAP file when Load Fix Address is enabled.
                 if self.Target in ["", "all", "fds"]:
@@ -1832,7 +1883,8 @@ class Build():
                         # Check whether the set fix address is above 4G for 32bit image.
                         #
                         if (Arch == 'IA32' or Arch == 'ARM') and self.LoadFixAddress != 0xFFFFFFFFFFFFFFFF and self.LoadFixAddress >= 0x100000000:
-                            EdkLogger.error("build", PARAMETER_INVALID, "FIX_LOAD_TOP_MEMORY_ADDRESS can't be set to larger than or equal to 4G for the platform with IA32 or ARM arch modules")
+                            EdkLogger.error(
+                                "build", PARAMETER_INVALID, "FIX_LOAD_TOP_MEMORY_ADDRESS can't be set to larger than or equal to 4G for the platform with IA32 or ARM arch modules")
                     #
                     # Get Module List
                     #
@@ -1862,10 +1914,10 @@ class Build():
                     #
                     # Save MAP buffer into MAP file.
                     #
-                    self._SaveMapFile (MapBuffer, Wa)
+                    self._SaveMapFile(MapBuffer, Wa)
                 self.CreateGuidedSectionToolsFile(Wa)
 
-    ## Build active module for different build targets, different tool chains and different archs
+    # Build active module for different build targets, different tool chains and different archs
     #
     def _BuildModule(self):
         for BuildTarget in self.BuildTargetList:
@@ -1882,23 +1934,23 @@ class Build():
                 # AutoGen first
                 #
                 Wa = WorkspaceAutoGen(
-                        self.WorkspaceDir,
-                        self.PlatformFile,
-                        BuildTarget,
-                        ToolChain,
-                        self.ArchList,
-                        self.BuildDatabase,
-                        self.TargetTxt,
-                        self.ToolDef,
-                        self.Fdf,
-                        self.FdList,
-                        self.FvList,
-                        self.CapList,
-                        self.SkuId,
-                        self.UniFlag,
-                        self.Progress,
-                        self.ModuleFile
-                        )
+                    self.WorkspaceDir,
+                    self.PlatformFile,
+                    BuildTarget,
+                    ToolChain,
+                    self.ArchList,
+                    self.BuildDatabase,
+                    self.TargetTxt,
+                    self.ToolDef,
+                    self.Fdf,
+                    self.FdList,
+                    self.FvList,
+                    self.CapList,
+                    self.SkuId,
+                    self.UniFlag,
+                    self.Progress,
+                    self.ModuleFile
+                )
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 Wa.CreateMakeFile(False)
@@ -1921,7 +1973,7 @@ class Build():
                     Pa = PlatformAutoGen(Wa, self.PlatformFile, BuildTarget, ToolChain, Arch)
                     for Module in Pa.Platform.Modules:
                         if self.ModuleFile.Dir == Module.Dir and self.ModuleFile.Name == Module.Name:
-                            Ma = ModuleAutoGen(Wa, Module, BuildTarget, ToolChain, Arch, self.PlatformFile,Pa.DataPipe)
+                            Ma = ModuleAutoGen(Wa, Module, BuildTarget, ToolChain, Arch, self.PlatformFile, Pa.DataPipe)
                             if Ma is None:
                                 continue
                             if Ma.PcdIsDriver:
@@ -1966,14 +2018,15 @@ class Build():
                     MakeStart = time.time()
                     for Ma in self.BuildModules:
                         if not Ma.IsBinaryModule:
-                            Bt = BuildTask.New(ModuleMakeUnit(Ma, Pa.BuildCommand,self.Target))
+                            Bt = BuildTask.New(ModuleMakeUnit(Ma, Pa.BuildCommand, self.Target))
                         # Break build if any build thread has error
                         if BuildTask.HasError():
                             # we need a full version of makefile for platform
                             ExitFlag.set()
                             BuildTask.WaitForComplete()
                             Pa.CreateMakeFile(False)
-                            EdkLogger.error("build", BUILD_ERROR, "Failed to build module", ExtraData=GlobalData.gBuildingModule)
+                            EdkLogger.error("build", BUILD_ERROR, "Failed to build module",
+                                            ExtraData=GlobalData.gBuildingModule)
                         # Start task scheduler
                         if not BuildTask.IsOnGoing():
                             BuildTask.StartScheduler(self.ThreadNumber, ExitFlag)
@@ -1981,7 +2034,8 @@ class Build():
                     # in case there's an interruption. we need a full version of makefile for platform
                     Pa.CreateMakeFile(False)
                     if BuildTask.HasError():
-                        EdkLogger.error("build", BUILD_ERROR, "Failed to build module", ExtraData=GlobalData.gBuildingModule)
+                        EdkLogger.error("build", BUILD_ERROR, "Failed to build module",
+                                        ExtraData=GlobalData.gBuildingModule)
                     self.MakeTime += int(round((time.time() - MakeStart)))
 
                 MakeContiue = time.time()
@@ -1997,19 +2051,20 @@ class Build():
                 self.BuildModules = []
                 self.MakeTime += int(round((time.time() - MakeContiue)))
                 if BuildTask.HasError():
-                    EdkLogger.error("build", BUILD_ERROR, "Failed to build module", ExtraData=GlobalData.gBuildingModule)
+                    EdkLogger.error("build", BUILD_ERROR, "Failed to build module",
+                                    ExtraData=GlobalData.gBuildingModule)
 
                 self.BuildReport.AddPlatformReport(Wa, MaList)
                 if MaList == []:
                     EdkLogger.error(
-                                'build',
-                                BUILD_ERROR,
-                                "Module for [%s] is not a component of active platform."\
-                                " Please make sure that the ARCH and inf file path are"\
-                                " given in the same as in [%s]" % \
-                                    (', '.join(Wa.ArchList), self.PlatformFile),
-                                ExtraData=self.ModuleFile
-                                )
+                        'build',
+                        BUILD_ERROR,
+                        "Module for [%s] is not a component of active platform."
+                        " Please make sure that the ARCH and inf file path are"
+                        " given in the same as in [%s]" %
+                        (', '.join(Wa.ArchList), self.PlatformFile),
+                        ExtraData=self.ModuleFile
+                    )
                 # Create MAP file when Load Fix Address is enabled.
                 if self.Target == "fds" and self.Fdf:
                     for Arch in Wa.ArchList:
@@ -2017,7 +2072,8 @@ class Build():
                         # Check whether the set fix address is above 4G for 32bit image.
                         #
                         if (Arch == 'IA32' or Arch == 'ARM') and self.LoadFixAddress != 0xFFFFFFFFFFFFFFFF and self.LoadFixAddress >= 0x100000000:
-                            EdkLogger.error("build", PARAMETER_INVALID, "FIX_LOAD_TOP_MEMORY_ADDRESS can't be set to larger than or equal to 4G for the platorm with IA32 or ARM arch modules")
+                            EdkLogger.error(
+                                "build", PARAMETER_INVALID, "FIX_LOAD_TOP_MEMORY_ADDRESS can't be set to larger than or equal to 4G for the platorm with IA32 or ARM arch modules")
                     #
                     # Get Module List
                     #
@@ -2048,9 +2104,9 @@ class Build():
                     #
                     # Save MAP buffer into MAP file.
                     #
-                    self._SaveMapFile (MapBuffer, Wa)
+                    self._SaveMapFile(MapBuffer, Wa)
 
-    def _GenFfsCmd(self,ArchList):
+    def _GenFfsCmd(self, ArchList):
         # convert dictionary of Cmd:(Inf,Arch)
         # to a new dictionary of (Inf,Arch):Cmd,Cmd,Cmd...
         CmdSetDict = defaultdict(set)
@@ -2059,8 +2115,9 @@ class Build():
             tmpInf, tmpArch = GenFfsDict[Cmd]
             CmdSetDict[tmpInf, tmpArch].add(Cmd)
         return CmdSetDict
+
     def VerifyAutoGenFiles(self):
-        AutoGenIdFile = os.path.join(GlobalData.gConfDirectory,".AutoGenIdFile.txt")
+        AutoGenIdFile = os.path.join(GlobalData.gConfDirectory, ".AutoGenIdFile.txt")
         try:
             with open(AutoGenIdFile) as fd:
                 lines = fd.readlines()
@@ -2075,7 +2132,7 @@ class Build():
                 PlatformGuid = line.split("=")[1].strip()
         GlobalVarList = []
         for arch in ArchList:
-            global_var = os.path.join(BuildDir, "GlobalVar_%s_%s.bin" % (str(PlatformGuid),arch))
+            global_var = os.path.join(BuildDir, "GlobalVar_%s_%s.bin" % (str(PlatformGuid), arch))
             if not os.path.exists(global_var):
                 return None
             GlobalVarList.append(global_var)
@@ -2094,22 +2151,23 @@ class Build():
             ModuleBuildDirectoryList = data_pipe.Get("ModuleBuildDirectoryList")
 
             for m_build_dir in LibraryBuildDirectoryList:
-                if not os.path.exists(os.path.join(m_build_dir,self.MakeFileName)):
+                if not os.path.exists(os.path.join(m_build_dir, self.MakeFileName)):
                     return None
             for m_build_dir in ModuleBuildDirectoryList:
-                if not os.path.exists(os.path.join(m_build_dir,self.MakeFileName)):
+                if not os.path.exists(os.path.join(m_build_dir, self.MakeFileName)):
                     return None
             Wa = WorkSpaceInfo(
-                workspacedir,active_p,target,toolchain,archlist
-                )
-            Pa = PlatformInfo(Wa, active_p, target, toolchain, Arch,data_pipe)
+                workspacedir, active_p, target, toolchain, archlist
+            )
+            Pa = PlatformInfo(Wa, active_p, target, toolchain, Arch, data_pipe)
             Wa.AutoGenObjectList.append(Pa)
         return Wa
-    def SetupMakeSetting(self,Wa):
+
+    def SetupMakeSetting(self, Wa):
         BuildModules = []
         for Pa in Wa.AutoGenObjectList:
             for m in Pa._MbList:
-                ma = ModuleAutoGen(Wa,m.MetaFile, Pa.BuildTarget, Wa.ToolChain, Pa.Arch, Pa.MetaFile,Pa.DataPipe)
+                ma = ModuleAutoGen(Wa, m.MetaFile, Pa.BuildTarget, Wa.ToolChain, Pa.Arch, Pa.MetaFile, Pa.DataPipe)
                 BuildModules.append(ma)
         fdf_file = Wa.FlashDefinition
         if fdf_file:
@@ -2121,34 +2179,35 @@ class Build():
                 for FdRegion in FdDict.RegionList:
                     if str(FdRegion.RegionType) == 'FILE' and self.Platform.VpdToolGuid in str(FdRegion.RegionDataList):
                         if int(FdRegion.Offset) % 8 != 0:
-                            EdkLogger.error("build", FORMAT_INVALID, 'The VPD Base Address %s must be 8-byte aligned.' % (FdRegion.Offset))
+                            EdkLogger.error("build", FORMAT_INVALID,
+                                            'The VPD Base Address %s must be 8-byte aligned.' % (FdRegion.Offset))
             Wa.FdfProfile = Fdf.Profile
             self.Fdf = Fdf
         else:
             self.Fdf = None
         return BuildModules
 
-    ## Build a platform in multi-thread mode
+    # Build a platform in multi-thread mode
     #
-    def PerformAutoGen(self,BuildTarget,ToolChain):
+    def PerformAutoGen(self, BuildTarget, ToolChain):
         WorkspaceAutoGenTime = time.time()
         Wa = WorkspaceAutoGen(
-                self.WorkspaceDir,
-                self.PlatformFile,
-                BuildTarget,
-                ToolChain,
-                self.ArchList,
-                self.BuildDatabase,
-                self.TargetTxt,
-                self.ToolDef,
-                self.Fdf,
-                self.FdList,
-                self.FvList,
-                self.CapList,
-                self.SkuId,
-                self.UniFlag,
-                self.Progress
-                )
+            self.WorkspaceDir,
+            self.PlatformFile,
+            BuildTarget,
+            ToolChain,
+            self.ArchList,
+            self.BuildDatabase,
+            self.TargetTxt,
+            self.ToolDef,
+            self.Fdf,
+            self.FdList,
+            self.FvList,
+            self.CapList,
+            self.SkuId,
+            self.UniFlag,
+            self.Progress
+        )
         self.Fdf = Wa.FdfFile
         self.LoadFixAddress = Wa.Platform.LoadFixAddress
         self.BuildReport.AddPlatformReport(Wa)
@@ -2162,7 +2221,7 @@ class Build():
         self.AutoGenTime += int(round((time.time() - WorkspaceAutoGenTime)))
         BuildModules = []
         for Arch in Wa.ArchList:
-            PcdMaList    = []
+            PcdMaList = []
             AutoGenStart = time.time()
             GlobalData.gGlobalDefines['ARCH'] = Arch
             Pa = PlatformAutoGen(Wa, self.PlatformFile, BuildTarget, ToolChain, Arch)
@@ -2178,26 +2237,27 @@ class Build():
                     if Inf in Pa.Platform.Modules:
                         continue
                     ModuleList.append(Inf)
-            Pa.DataPipe.DataContainer = {"FfsCommand":CmdListDict}
+            Pa.DataPipe.DataContainer = {"FfsCommand": CmdListDict}
             Pa.DataPipe.DataContainer = {"Workspace_timestamp": Wa._SrcTimeStamp}
             Pa.DataPipe.DataContainer = {"CommandTarget": self.Target}
             Pa.CreateLibModuelDirs()
             # Fetch the MakeFileName.
             self.MakeFileName = Pa.MakeFileName
 
-            Pa.DataPipe.DataContainer = {"LibraryBuildDirectoryList":Pa.LibraryBuildDirectoryList}
-            Pa.DataPipe.DataContainer = {"ModuleBuildDirectoryList":Pa.ModuleBuildDirectoryList}
+            Pa.DataPipe.DataContainer = {"LibraryBuildDirectoryList": Pa.LibraryBuildDirectoryList}
+            Pa.DataPipe.DataContainer = {"ModuleBuildDirectoryList": Pa.ModuleBuildDirectoryList}
             Pa.DataPipe.DataContainer = {"FdsCommandDict": Wa.GenFdsCommandDict}
             # Prepare the cache share data for multiprocessing
-            Pa.DataPipe.DataContainer = {"gPlatformHashFile":GlobalData.gPlatformHashFile}
+            Pa.DataPipe.DataContainer = {"gPlatformHashFile": GlobalData.gPlatformHashFile}
             ModuleCodaFile = {}
             for ma in Pa.ModuleAutoGenList:
-                ModuleCodaFile[(ma.MetaFile.File,ma.MetaFile.Root,ma.Arch,ma.MetaFile.Path)] = [item.Target for item in ma.CodaTargetList]
-            Pa.DataPipe.DataContainer = {"ModuleCodaFile":ModuleCodaFile}
+                ModuleCodaFile[(ma.MetaFile.File, ma.MetaFile.Root, ma.Arch, ma.MetaFile.Path)] = [
+                    item.Target for item in ma.CodaTargetList]
+            Pa.DataPipe.DataContainer = {"ModuleCodaFile": ModuleCodaFile}
             # ModuleList contains all driver modules only
             for Module in ModuleList:
                 # Get ModuleAutoGen object to generate C code file and makefile
-                Ma = ModuleAutoGen(Wa, Module, BuildTarget, ToolChain, Arch, self.PlatformFile,Pa.DataPipe)
+                Ma = ModuleAutoGen(Wa, Module, BuildTarget, ToolChain, Arch, self.PlatformFile, Pa.DataPipe)
                 if Ma is None:
                     continue
                 if Ma.PcdIsDriver:
@@ -2211,15 +2271,15 @@ class Build():
             cqueue = mp.Queue()
             for m in Pa.GetAllModuleInfo:
                 mqueue.put(m)
-                module_file,module_root,module_path,module_basename,\
-                    module_originalpath,module_arch,IsLib = m
-                Ma = ModuleAutoGen(Wa, PathClass(module_path, Wa), BuildTarget,\
-                                  ToolChain, Arch, self.PlatformFile,Pa.DataPipe)
+                module_file, module_root, module_path, module_basename,\
+                    module_originalpath, module_arch, IsLib = m
+                Ma = ModuleAutoGen(Wa, PathClass(module_path, Wa), BuildTarget,
+                                   ToolChain, Arch, self.PlatformFile, Pa.DataPipe)
                 self.AllModules.add(Ma)
-            data_pipe_file = os.path.join(Pa.BuildDir, "GlobalVar_%s_%s.bin" % (str(Pa.Guid),Pa.Arch))
+            data_pipe_file = os.path.join(Pa.BuildDir, "GlobalVar_%s_%s.bin" % (str(Pa.Guid), Pa.Arch))
             Pa.DataPipe.dump(data_pipe_file)
 
-            mqueue.put((None,None,None,None,None,None,None))
+            mqueue.put((None, None, None, None, None, None, None))
             autogen_rt, errorcode = self.StartAutoGen(mqueue, Pa.DataPipe, self.SkipAutoGen, PcdMaList, cqueue)
 
             if not autogen_rt:
@@ -2230,8 +2290,8 @@ class Build():
             if GlobalData.gUseHashCache:
                 for item in GlobalData.gModuleAllCacheStatus:
                     (MetaFilePath, Arch, CacheStr, Status) = item
-                    Ma = ModuleAutoGen(Wa, PathClass(MetaFilePath, Wa), BuildTarget,\
-                                      ToolChain, Arch, self.PlatformFile,Pa.DataPipe)
+                    Ma = ModuleAutoGen(Wa, PathClass(MetaFilePath, Wa), BuildTarget,
+                                       ToolChain, Arch, self.PlatformFile, Pa.DataPipe)
                     if CacheStr == "PreMakeCache" and Status == False:
                         self.PreMakeCacheMiss.add(Ma)
                     if CacheStr == "PreMakeCache" and Status == True:
@@ -2243,8 +2303,8 @@ class Build():
                         self.MakeCacheHit.add(Ma)
                         GlobalData.gModuleCacheHit.add(Ma)
             self.AutoGenTime += int(round((time.time() - AutoGenStart)))
-        AutoGenIdFile = os.path.join(GlobalData.gConfDirectory,".AutoGenIdFile.txt")
-        with open(AutoGenIdFile,"w") as fw:
+        AutoGenIdFile = os.path.join(GlobalData.gConfDirectory, ".AutoGenIdFile.txt")
+        with open(AutoGenIdFile, "w") as fw:
             fw.write("Arch=%s\n" % "|".join((Wa.ArchList)))
             fw.write("BuildDir=%s\n" % Wa.BuildDir)
             fw.write("PlatformGuid=%s\n" % str(Wa.AutoGenObjectList[0].Guid))
@@ -2276,12 +2336,12 @@ class Build():
                     Wa = self.VerifyAutoGenFiles()
                     if Wa is None:
                         self.SkipAutoGen = False
-                        Wa, self.BuildModules = self.PerformAutoGen(BuildTarget,ToolChain)
+                        Wa, self.BuildModules = self.PerformAutoGen(BuildTarget, ToolChain)
                     else:
                         GlobalData.gAutoGenPhase = True
                         self.BuildModules = self.SetupMakeSetting(Wa)
                 else:
-                    Wa, self.BuildModules = self.PerformAutoGen(BuildTarget,ToolChain)
+                    Wa, self.BuildModules = self.PerformAutoGen(BuildTarget, ToolChain)
                 Pa = Wa.AutoGenObjectList[0]
                 GlobalData.gAutoGenPhase = False
 
@@ -2295,14 +2355,15 @@ class Build():
                     for Ma in set(self.BuildModules):
                         # Generate build task for the module
                         if not Ma.IsBinaryModule:
-                            Bt = BuildTask.New(ModuleMakeUnit(Ma, Pa.BuildCommand,self.Target))
+                            Bt = BuildTask.New(ModuleMakeUnit(Ma, Pa.BuildCommand, self.Target))
                         # Break build if any build thread has error
                         if BuildTask.HasError():
                             # we need a full version of makefile for platform
                             ExitFlag.set()
                             BuildTask.WaitForComplete()
                             Pa.CreateMakeFile(False)
-                            EdkLogger.error("build", BUILD_ERROR, "Failed to build module", ExtraData=GlobalData.gBuildingModule)
+                            EdkLogger.error("build", BUILD_ERROR, "Failed to build module",
+                                            ExtraData=GlobalData.gBuildingModule)
                         # Start task scheduler
                         if not BuildTask.IsOnGoing():
                             BuildTask.StartScheduler(self.ThreadNumber, ExitFlag)
@@ -2310,7 +2371,8 @@ class Build():
                     # in case there's an interruption. we need a full version of makefile for platform
 
                     if BuildTask.HasError():
-                        EdkLogger.error("build", BUILD_ERROR, "Failed to build module", ExtraData=GlobalData.gBuildingModule)
+                        EdkLogger.error("build", BUILD_ERROR, "Failed to build module",
+                                        ExtraData=GlobalData.gBuildingModule)
                     self.MakeTime += int(round((time.time() - MakeStart)))
 
                 MakeContiue = time.time()
@@ -2338,7 +2400,8 @@ class Build():
                 # has been signaled.
                 #
                 if BuildTask.HasError():
-                    EdkLogger.error("build", BUILD_ERROR, "Failed to build module", ExtraData=GlobalData.gBuildingModule)
+                    EdkLogger.error("build", BUILD_ERROR, "Failed to build module",
+                                    ExtraData=GlobalData.gBuildingModule)
 
                 # Create MAP file when Load Fix Address is enabled.
                 if self.Target in ["", "all", "fds"]:
@@ -2347,7 +2410,8 @@ class Build():
                         # Check whether the set fix address is above 4G for 32bit image.
                         #
                         if (Arch == 'IA32' or Arch == 'ARM') and self.LoadFixAddress != 0xFFFFFFFFFFFFFFFF and self.LoadFixAddress >= 0x100000000:
-                            EdkLogger.error("build", PARAMETER_INVALID, "FIX_LOAD_TOP_MEMORY_ADDRESS can't be set to larger than or equal to 4G for the platorm with IA32 or ARM arch modules")
+                            EdkLogger.error(
+                                "build", PARAMETER_INVALID, "FIX_LOAD_TOP_MEMORY_ADDRESS can't be set to larger than or equal to 4G for the platorm with IA32 or ARM arch modules")
 
                     #
                     # Rebase module to the preferred memory address before GenFds
@@ -2378,7 +2442,7 @@ class Build():
                     self._SaveMapFile(MapBuffer, Wa)
                 self.CreateGuidedSectionToolsFile(Wa)
 
-    ## GetFreeSizeThreshold()
+    # GetFreeSizeThreshold()
     #
     #   @retval int             Threshold value
     #
@@ -2392,7 +2456,8 @@ class Build():
                 else:
                     Threshold = int(Threshold_Str)
             except:
-                EdkLogger.warn("build", 'incorrect value for FV_SPARE_SPACE_THRESHOLD %s.Only decimal or hex format is allowed.' % Threshold_Str)
+                EdkLogger.warn(
+                    "build", 'incorrect value for FV_SPARE_SPACE_THRESHOLD %s.Only decimal or hex format is allowed.' % Threshold_Str)
         return Threshold
 
     def CheckFreeSizeThreshold(self, Threshold=None, FvDir=None):
@@ -2401,7 +2466,8 @@ class Build():
         if not isinstance(FvDir, str) or not FvDir:
             return
         FdfParserObject = GlobalData.gFdfParser
-        FvRegionNameList = [FvName for FvName in FdfParserObject.Profile.FvDict if FdfParserObject.Profile.FvDict[FvName].FvRegionInFD]
+        FvRegionNameList = [
+            FvName for FvName in FdfParserObject.Profile.FvDict if FdfParserObject.Profile.FvDict[FvName].FvRegionInFD]
         for FvName in FdfParserObject.Profile.FvDict:
             if FvName in FvRegionNameList:
                 FvSpaceInfoFileName = os.path.join(FvDir, FvName.upper() + '.Fv.map')
@@ -2417,9 +2483,9 @@ class Build():
                                                     FvName, FreeSizeValue, Threshold))
                             break
 
-    ## Generate GuidedSectionTools.txt in the FV directories.
+    # Generate GuidedSectionTools.txt in the FV directories.
     #
-    def CreateGuidedSectionToolsFile(self,Wa):
+    def CreateGuidedSectionToolsFile(self, Wa):
         for BuildTarget in self.BuildTargetList:
             for ToolChain in self.ToolChainList:
                 FvDir = Wa.FvDir
@@ -2436,13 +2502,14 @@ class Build():
                             continue
                         if Platform.Arch != Arch:
                             continue
-                        if hasattr (Platform, 'BuildOption'):
+                        if hasattr(Platform, 'BuildOption'):
                             for Tool in Platform.BuildOption:
                                 if 'GUID' in Platform.BuildOption[Tool]:
                                     if 'PATH' in Platform.BuildOption[Tool]:
                                         value = Platform.BuildOption[Tool]['GUID']
                                         if value in guidList:
-                                            EdkLogger.error("build", FORMAT_INVALID, "Duplicate GUID value %s used with Tool %s in DSC [BuildOptions]." % (value, Tool))
+                                            EdkLogger.error(
+                                                "build", FORMAT_INVALID, "Duplicate GUID value %s used with Tool %s in DSC [BuildOptions]." % (value, Tool))
                                         path = Platform.BuildOption[Tool]['PATH']
                                         guidList.append(value)
                                         guidAttribs.append((value, Tool, path))
@@ -2451,7 +2518,8 @@ class Build():
                                 if 'PATH' in Platform.ToolDefinition[Tool]:
                                     value = Platform.ToolDefinition[Tool]['GUID']
                                     if value in tooldefguidList:
-                                        EdkLogger.error("build", FORMAT_INVALID, "Duplicate GUID value %s used with Tool %s in tools_def.txt." % (value, Tool))
+                                        EdkLogger.error(
+                                            "build", FORMAT_INVALID, "Duplicate GUID value %s used with Tool %s in tools_def.txt." % (value, Tool))
                                     tooldefguidList.append(value)
                                     if value in guidList:
                                         # Already added by platform
@@ -2460,7 +2528,7 @@ class Build():
                                     guidList.append(value)
                                     guidAttribs.append((value, Tool, path))
                     # Sort by GuidTool name
-                    guidAttribs = sorted (guidAttribs, key=lambda x: x[1])
+                    guidAttribs = sorted(guidAttribs, key=lambda x: x[1])
                     # Write out GuidedSecTools.txt
                     toolsFile = os.path.join(FvDir, 'GuidedSectionTools.txt')
                     toolsFile = open(toolsFile, 'wt')
@@ -2468,14 +2536,14 @@ class Build():
                         print(' '.join(guidedSectionTool), file=toolsFile)
                     toolsFile.close()
 
-    ## Returns the real path of the tool.
+    # Returns the real path of the tool.
     #
-    def GetRealPathOfTool (self, tool):
+    def GetRealPathOfTool(self, tool):
         if os.path.exists(tool):
             return os.path.realpath(tool)
         return tool
 
-    ## Launch the module or platform build
+    # Launch the module or platform build
     #
     def Launch(self):
         self.AllDrivers = set()
@@ -2511,7 +2579,7 @@ class Build():
         for Module in self.PreMakeCacheMiss:
             Module.GenPreMakefileHashList()
 
-    ## Do some clean-up works when error occurred
+    # Do some clean-up works when error occurred
     def Relinquish(self):
         OldLogLevel = EdkLogger.GetLevel()
         EdkLogger.SetLevel(EdkLogger.ERROR)
@@ -2519,6 +2587,7 @@ class Build():
         if self.SpawnMode == True:
             BuildTask.Abort()
         EdkLogger.SetLevel(OldLogLevel)
+
 
 def ParseDefines(DefineList=[]):
     DefineDict = {}
@@ -2537,7 +2606,6 @@ def ParseDefines(DefineList=[]):
     return DefineDict
 
 
-
 def LogBuildTime(Time):
     if Time:
         TimeDurStr = ''
@@ -2549,13 +2617,15 @@ def LogBuildTime(Time):
         return TimeDurStr
     else:
         return None
+
+
 def ThreadNum():
     OptionParser = MyOptionParser()
-    if not OptionParser.BuildOption and not OptionParser.BuildTarget:
+    if not OptionParser.BuildArguments:
         OptionParser.GetOption()
-    BuildOption, BuildTarget = OptionParser.BuildOption, OptionParser.BuildTarget
-    ThreadNumber = BuildOption.ThreadNumber
-    GlobalData.gCmdConfDir = BuildOption.ConfDirectory
+    BuildArguments = OptionParser.BuildArguments
+    ThreadNumber = BuildArguments.ThreadNumber
+    GlobalData.gCmdConfDir = BuildArguments.ConfDirectory
     if ThreadNumber is None:
         TargetObj = TargetTxtDict()
         ThreadNumber = TargetObj.Target.TargetTxtDictionary[TAB_TAT_DEFINES_MAX_CONCURRENT_THREAD_NUMBER]
@@ -2570,7 +2640,9 @@ def ThreadNum():
         except (ImportError, NotImplementedError):
             ThreadNumber = 1
     return ThreadNumber
-## Tool entrance method
+
+
+# Tool entrance method
 #
 # This method mainly dispatch specific methods per the command line options.
 # If no error found, return zero value so the caller of this tool can know
@@ -2580,6 +2652,8 @@ def ThreadNum():
 #   @retval 1     Tool failed
 #
 LogQMaxSize = ThreadNum() * 10
+
+
 def Main():
     StartTime = time.time()
 
@@ -2594,29 +2668,29 @@ def Main():
     # Parse the options and args
     #
     OptionParser = MyOptionParser()
-    if not OptionParser.BuildOption and not OptionParser.BuildTarget:
+    if not OptionParser.BuildArguments:
         OptionParser.GetOption()
-    Option, Target = OptionParser.BuildOption, OptionParser.BuildTarget
-    GlobalData.gOptions = Option
-    GlobalData.gCaseInsensitive = Option.CaseInsensitive
+    Arguments = OptionParser.BuildArguments
+    GlobalData.gArguments = Arguments
+    GlobalData.gCaseInsensitive = Arguments.CaseInsensitive
 
     # Set log level
     LogLevel = EdkLogger.INFO
-    if Option.verbose is not None:
+    if Arguments.verbose:
         EdkLogger.SetLevel(EdkLogger.VERBOSE)
         LogLevel = EdkLogger.VERBOSE
-    elif Option.quiet is not None:
+    elif Arguments.quiet:
         EdkLogger.SetLevel(EdkLogger.QUIET)
         LogLevel = EdkLogger.QUIET
-    elif Option.debug is not None:
-        EdkLogger.SetLevel(Option.debug + 1)
-        LogLevel = Option.debug + 1
+    elif Arguments.debug is not None:
+        EdkLogger.SetLevel(Arguments.debug + 1)
+        LogLevel = Arguments.debug + 1
     else:
         EdkLogger.SetLevel(EdkLogger.INFO)
 
-    if Option.WarningAsError == True:
+    if Arguments.WarningAsError:
         EdkLogger.SetWarningAsError()
-    Log_Agent = LogAgent(LogQ,LogLevel,Option.LogFile)
+    Log_Agent = LogAgent(LogQ, LogLevel, Arguments.LogFile)
     Log_Agent.start()
 
     if platform.platform().find("Windows") >= 0:
@@ -2625,28 +2699,19 @@ def Main():
         GlobalData.gIsWindows = False
 
     EdkLogger.quiet("Build environment: %s" % platform.platform())
-    EdkLogger.quiet(time.strftime("Build start time: %H:%M:%S, %b.%d %Y\n", time.localtime()));
+    EdkLogger.quiet(time.strftime("Build start time: %H:%M:%S, %b.%d %Y\n", time.localtime()))
     ReturnCode = 0
     MyBuild = None
     BuildError = True
-    try:
-        if len(Target) == 0:
-            Target = "all"
-        elif len(Target) >= 2:
-            EdkLogger.error("build", OPTION_NOT_SUPPORTED, "More than one targets are not supported.",
-                            ExtraData="Please select one of: %s" % (' '.join(gSupportedTarget)))
-        else:
-            Target = Target[0].lower()
 
-        if Target not in gSupportedTarget:
-            EdkLogger.error("build", OPTION_NOT_SUPPORTED, "Not supported target [%s]." % Target,
-                            ExtraData="Please select one of: %s" % (' '.join(gSupportedTarget)))
+    try:
+        Target = Arguments.Target.lower()
 
         #
         # Check environment variable: EDK_TOOLS_PATH, WORKSPACE, PATH
         #
         CheckEnvVariable()
-        GlobalData.gCommandLineDefines.update(ParseDefines(Option.Macros))
+        GlobalData.gCommandLineDefines.update(ParseDefines(Arguments.Macros))
 
         Workspace = os.getenv("WORKSPACE")
         #
@@ -2655,43 +2720,40 @@ def Main():
         GlobalData.gAllFiles = Utils.DirCache(Workspace)
 
         WorkingDirectory = os.getcwd()
-        if not Option.ModuleFile:
+        if not Arguments.ModuleFile:
             FileList = glob.glob(os.path.normpath(os.path.join(WorkingDirectory, '*.inf')))
             FileNum = len(FileList)
             if FileNum >= 2:
                 EdkLogger.error("build", OPTION_NOT_SUPPORTED, "There are %d INF files in %s." % (FileNum, WorkingDirectory),
                                 ExtraData="Please use '-m <INF_FILE_PATH>' switch to choose one.")
             elif FileNum == 1:
-                Option.ModuleFile = NormFile(FileList[0], Workspace)
+                Arguments.ModuleFile = NormFile(FileList[0], Workspace)
 
-        if Option.ModuleFile:
-            if os.path.isabs (Option.ModuleFile):
-                if os.path.normcase (os.path.normpath(Option.ModuleFile)).find (Workspace) == 0:
-                    Option.ModuleFile = NormFile(os.path.normpath(Option.ModuleFile), Workspace)
-            Option.ModuleFile = PathClass(Option.ModuleFile, Workspace)
-            ErrorCode, ErrorInfo = Option.ModuleFile.Validate(".inf", False)
+        if Arguments.ModuleFile:
+            if os.path.isabs(Arguments.ModuleFile):
+                if os.path.normcase(os.path.normpath(Arguments.ModuleFile)).find(Workspace) == 0:
+                    Arguments.ModuleFile = NormFile(os.path.normpath(Arguments.ModuleFile), Workspace)
+            Arguments.ModuleFile = PathClass(Arguments.ModuleFile, Workspace)
+            ErrorCode, ErrorInfo = Arguments.ModuleFile.Validate(".inf", False)
             if ErrorCode != 0:
                 EdkLogger.error("build", ErrorCode, ExtraData=ErrorInfo)
 
-        if Option.PlatformFile is not None:
-            if os.path.isabs (Option.PlatformFile):
-                if os.path.normcase (os.path.normpath(Option.PlatformFile)).find (Workspace) == 0:
-                    Option.PlatformFile = NormFile(os.path.normpath(Option.PlatformFile), Workspace)
-            Option.PlatformFile = PathClass(Option.PlatformFile, Workspace)
+        if Arguments.PlatformFile is not None:
+            if os.path.isabs(Arguments.PlatformFile):
+                if os.path.normcase(os.path.normpath(Arguments.PlatformFile)).find(Workspace) == 0:
+                    Arguments.PlatformFile = NormFile(os.path.normpath(Arguments.PlatformFile), Workspace)
+            Arguments.PlatformFile = PathClass(Arguments.PlatformFile, Workspace)
 
-        if Option.FdfFile is not None:
-            if os.path.isabs (Option.FdfFile):
-                if os.path.normcase (os.path.normpath(Option.FdfFile)).find (Workspace) == 0:
-                    Option.FdfFile = NormFile(os.path.normpath(Option.FdfFile), Workspace)
-            Option.FdfFile = PathClass(Option.FdfFile, Workspace)
-            ErrorCode, ErrorInfo = Option.FdfFile.Validate(".fdf", False)
+        if Arguments.FdfFile is not None:
+            if os.path.isabs(Arguments.FdfFile):
+                if os.path.normcase(os.path.normpath(Arguments.FdfFile)).find(Workspace) == 0:
+                    Arguments.FdfFile = NormFile(os.path.normpath(Arguments.FdfFile), Workspace)
+            Arguments.FdfFile = PathClass(Arguments.FdfFile, Workspace)
+            ErrorCode, ErrorInfo = Arguments.FdfFile.Validate(".fdf", False)
             if ErrorCode != 0:
                 EdkLogger.error("build", ErrorCode, ExtraData=ErrorInfo)
 
-        if Option.Flag is not None and Option.Flag not in ['-c', '-s']:
-            EdkLogger.error("build", OPTION_VALUE_INVALID, "UNI flag must be one of -c or -s")
-
-        MyBuild = Build(Target, Workspace, Option,LogQ)
+        MyBuild = Build(Target, Workspace, Arguments, LogQ)
         GlobalData.gCommandLineDefines['ARCH'] = ' '.join(MyBuild.ArchList)
         if not (MyBuild.LaunchPrebuildFlag and os.path.exists(MyBuild.PlatformBuildPath)):
             MyBuild.Launch()
@@ -2704,7 +2766,7 @@ def Main():
         if MyBuild is not None:
             # for multi-thread build exits safely
             MyBuild.Relinquish()
-        if Option is not None and Option.debug is not None:
+        if Arguments is not None and Arguments.debug is not None:
             EdkLogger.quiet("(Python %s on %s) " % (platform.python_version(), sys.platform) + traceback.format_exc())
         ReturnCode = X.args[0]
     except Warning as X:
@@ -2712,10 +2774,11 @@ def Main():
         if MyBuild is not None:
             # for multi-thread build exits safely
             MyBuild.Relinquish()
-        if Option is not None and Option.debug is not None:
+        if Arguments is not None and Arguments.debug is not None:
             EdkLogger.quiet("(Python %s on %s) " % (platform.python_version(), sys.platform) + traceback.format_exc())
         else:
-            EdkLogger.error(X.ToolName, FORMAT_INVALID, File=X.FileName, Line=X.LineNumber, ExtraData=X.Message, RaiseError=False)
+            EdkLogger.error(X.ToolName, FORMAT_INVALID, File=X.FileName,
+                            Line=X.LineNumber, ExtraData=X.Message, RaiseError=False)
         ReturnCode = FORMAT_INVALID
     except KeyboardInterrupt:
         if MyBuild is not None:
@@ -2723,7 +2786,7 @@ def Main():
             # for multi-thread build exits safely
             MyBuild.Relinquish()
         ReturnCode = ABORT_ERROR
-        if Option is not None and Option.debug is not None:
+        if Arguments is not None and Arguments.debug is not None:
             EdkLogger.quiet("(Python %s on %s) " % (platform.python_version(), sys.platform) + traceback.format_exc())
     except:
         if MyBuild is not None:
@@ -2738,12 +2801,12 @@ def Main():
                 MetaFile = Tb.tb_frame.f_locals['self'].MetaFile
             Tb = Tb.tb_next
         EdkLogger.error(
-                    "\nbuild",
-                    CODE_ERROR,
-                    "Unknown fatal error when processing [%s]" % MetaFile,
-                    ExtraData="\n(Please send email to %s for help, attaching following call stack trace!)\n" % MSG_EDKII_MAIL_ADDR,
-                    RaiseError=False
-                    )
+            "\nbuild",
+            CODE_ERROR,
+            "Unknown fatal error when processing [%s]" % MetaFile,
+            ExtraData="\n(Please send email to %s for help, attaching following call stack trace!)\n" % MSG_EDKII_MAIL_ADDR,
+            RaiseError=False
+        )
         EdkLogger.quiet("(Python %s on %s) " % (platform.python_version(), sys.platform) + traceback.format_exc())
         ReturnCode = CODE_ERROR
     finally:
@@ -2770,7 +2833,8 @@ def Main():
         BuildDurationStr = time.strftime("%H:%M:%S", BuildDuration)
     if MyBuild is not None:
         if not BuildError:
-            MyBuild.BuildReport.GenerateReport(BuildDurationStr, LogBuildTime(MyBuild.AutoGenTime), LogBuildTime(MyBuild.MakeTime), LogBuildTime(MyBuild.GenFdsTime))
+            MyBuild.BuildReport.GenerateReport(BuildDurationStr, LogBuildTime(
+                MyBuild.AutoGenTime), LogBuildTime(MyBuild.MakeTime), LogBuildTime(MyBuild.GenFdsTime))
 
     EdkLogger.SetLevel(EdkLogger.QUIET)
     EdkLogger.quiet("\n- %s -" % Conclusion)
@@ -2780,12 +2844,14 @@ def Main():
     Log_Agent.join()
     return ReturnCode
 
+
 if __name__ == '__main__':
     try:
         mp.set_start_method('spawn')
     except:
         pass
     r = Main()
-    ## 0-127 is a safe return range, and 1 is a standard default error
-    if r < 0 or r > 127: r = 1
+    # 0-127 is a safe return range, and 1 is a standard default error
+    if r < 0 or r > 127:
+        r = 1
     sys.exit(r)

--- a/edk2basetools/build/buildoptions.py
+++ b/edk2basetools/build/buildoptions.py
@@ -1,4 +1,4 @@
-## @file
+# @file
 # build a platform or a module
 #
 #  Copyright (c) 2014, Hewlett-Packard Development Company, L.P.<BR>
@@ -10,18 +10,10 @@
 
 # Version and Copyright
 from edk2basetools.Common.BuildVersion import gBUILD_VERSION
-from optparse import OptionParser
+from argparse import ArgumentParser
 VersionNumber = "0.60" + ' ' + gBUILD_VERSION
 __version__ = "%prog Version " + VersionNumber
 __copyright__ = "Copyright (c) 2007 - 2018, Intel Corporation  All rights reserved."
-
-gParamCheck = []
-def SingleCheckCallback(option, opt_str, value, parser):
-    if option not in gParamCheck:
-        setattr(parser.values, option.dest, value)
-        gParamCheck.append(option)
-    else:
-        parser.error("Option %s only allows one instance in command line!" % option)
 
 
 class MyOptionParser():
@@ -33,73 +25,101 @@ class MyOptionParser():
         return cls._instance
 
     def __init__(self):
-        if not hasattr(self, 'BuildOption'):
-            self.BuildOption = None
-        if not hasattr(self, 'BuildTarget'):
-            self.BuildTarget = None
+        if not hasattr(self, 'BuildArguments'):
+            self.BuildArguments = None
 
     def GetOption(self):
-        Parser = OptionParser(description=__copyright__, version=__version__, prog="build.exe", usage="%prog [options] [all|fds|genc|genmake|clean|cleanall|cleanlib|modules|libraries|run]")
-        Parser.add_option("-a", "--arch", action="append", dest="TargetArch",
-            help="ARCHS is one of list: IA32, X64, ARM, AARCH64, RISCV64 or EBC, which overrides target.txt's TARGET_ARCH definition. To specify more archs, please repeat this option.")
-        Parser.add_option("-p", "--platform", action="callback", type="string", dest="PlatformFile", callback=SingleCheckCallback,
-            help="Build the platform specified by the DSC file name argument, overriding target.txt's ACTIVE_PLATFORM definition.")
-        Parser.add_option("-m", "--module", action="callback", type="string", dest="ModuleFile", callback=SingleCheckCallback,
-            help="Build the module specified by the INF file name argument.")
-        Parser.add_option("-b", "--buildtarget", type="string", dest="BuildTarget", help="Using the TARGET to build the platform, overriding target.txt's TARGET definition.",
-                          action="append")
-        Parser.add_option("-t", "--tagname", action="append", type="string", dest="ToolChain",
-            help="Using the Tool Chain Tagname to build the platform, overriding target.txt's TOOL_CHAIN_TAG definition.")
-        Parser.add_option("-x", "--sku-id", action="callback", type="string", dest="SkuId", callback=SingleCheckCallback,
-            help="Using this name of SKU ID to build the platform, overriding SKUID_IDENTIFIER in DSC file.")
+        Parser = ArgumentParser(description=__copyright__, prog="edk2_build")
+        Parser.add_argument("Target", metavar="TARGET", type=str, choices=['all', 'genc', 'genmake', 'modules', 'libraries', 'fds', 'clean', 'cleanall', 'cleanlib',
+                            'run'], help="target is one of the list: all, fds, genc, genmake, clean, cleanall, cleanlib, modules, libraries, run", default="all", nargs='?')
+        Parser.add_argument('--version', action='version', version=__version__)
+        Parser.add_argument("-a", "--arch", action="append", dest="TargetArch", choices=['IA32', 'X64', 'ARM', 'AARCH64', 'RISCV64', 'EBC'],
+                            help="ARCHS is one of list: IA32, X64, ARM, AARCH64, RISCV64 or EBC, which overrides target.txt's TARGET_ARCH definition. To specify more archs, please repeat this option.")
+        Parser.add_argument("-p", "--platform", type=str, dest="PlatformFile",
+                            help="Build the platform specified by the DSC file name argument, overriding target.txt's ACTIVE_PLATFORM definition.")
+        Parser.add_argument("-m", "--module", type=str, dest="ModuleFile",
+                            help="Build the module specified by the INF file name argument.")
+        Parser.add_argument("-b", "--buildtarget", type=str, dest="BuildTarget", action="append",
+                            help="Using the TARGET to build the platform, overriding target.txt's TARGET definition.")
+        Parser.add_argument("-t", "--tagname", action="append", type=str, dest="ToolChain",
+                            help="Using the Tool Chain Tagname to build the platform, overriding target.txt's TOOL_CHAIN_TAG definition.")
+        Parser.add_argument("-x", "--sku-id", type=str, dest="SkuId",
+                            help="Using this name of SKU ID to build the platform, overriding SKUID_IDENTIFIER in DSC file.")
 
-        Parser.add_option("-n", action="callback", type="int", dest="ThreadNumber", callback=SingleCheckCallback,
-            help="Build the platform using multi-threaded compiler. The value overrides target.txt's MAX_CONCURRENT_THREAD_NUMBER. When value is set to 0, tool automatically detect number of "\
-                 "processor threads, set value to 1 means disable multi-thread build, and set value to more than 1 means user specify the threads number to build.")
+        Parser.add_argument("-n", type=int, dest="ThreadNumber", help="Build the platform using multi-threaded compiler. "
+                            "The value overrides target.txt's MAX_CONCURRENT_THREAD_NUMBER. "
+                            "When value is set to 0, tool automatically detect number of processor threads, "
+                            "set value to 1 means disable multi-thread build, "
+                            "and set value to more than 1 means user specify the threads number to build.")
 
-        Parser.add_option("-f", "--fdf", action="callback", type="string", dest="FdfFile", callback=SingleCheckCallback,
-            help="The name of the FDF file to use, which overrides the setting in the DSC file.")
-        Parser.add_option("-r", "--rom-image", action="append", type="string", dest="RomImage", default=[],
-            help="The name of FD to be generated. The name must be from [FD] section in FDF file.")
-        Parser.add_option("-i", "--fv-image", action="append", type="string", dest="FvImage", default=[],
-            help="The name of FV to be generated. The name must be from [FV] section in FDF file.")
-        Parser.add_option("-C", "--capsule-image", action="append", type="string", dest="CapName", default=[],
-            help="The name of Capsule to be generated. The name must be from [Capsule] section in FDF file.")
-        Parser.add_option("-u", "--skip-autogen", action="store_true", dest="SkipAutoGen", help="Skip AutoGen step.")
-        Parser.add_option("-e", "--re-parse", action="store_true", dest="Reparse", help="Re-parse all meta-data files.")
+        Parser.add_argument("-f", "--fdf", type=str, dest="FdfFile",
+                            help="The name of the FDF file to use, which overrides the setting in the DSC file.")
+        Parser.add_argument("-r", "--rom-image", action="append", type=str, dest="RomImage", default=[],
+                            help="The name of FD to be generated. The name must be from [FD] section in FDF file.")
+        Parser.add_argument("-i", "--fv-image", action="append", type=str, dest="FvImage", default=[],
+                            help="The name of FV to be generated. The name must be from [FV] section in FDF file.")
+        Parser.add_argument("-C", "--capsule-image", action="append", type=str, dest="CapName", default=[],
+                            help="The name of Capsule to be generated. The name must be from [Capsule] section in FDF file.")
+        Parser.add_argument("-u", "--skip-autogen", action="store_true", dest="SkipAutoGen", help="Skip AutoGen step.")
+        Parser.add_argument("-e", "--re-parse", action="store_true",
+                            dest="Reparse", help="Re-parse all meta-data files.")
 
-        Parser.add_option("-c", "--case-insensitive", action="store_true", dest="CaseInsensitive", default=False, help="Don't check case of file name.")
+        Parser.add_argument("-c", "--case-insensitive", action="store_true", dest="CaseInsensitive",
+                            default=False, help="Don't check case of file name.")
 
-        Parser.add_option("-w", "--warning-as-error", action="store_true", dest="WarningAsError", help="Treat warning in tools as error.")
-        Parser.add_option("-j", "--log", action="store", dest="LogFile", help="Put log in specified file as well as on console.")
+        Parser.add_argument("-w", "--warning-as-error", action="store_true",
+                            dest="WarningAsError", help="Treat warning in tools as error.")
+        Parser.add_argument("-j", "--log", action="store", dest="LogFile",
+                            help="Put log in specified file as well as on console.")
 
-        Parser.add_option("-s", "--silent", action="store_true", type=None, dest="SilentMode",
-            help="Make use of silent mode of (n)make.")
-        Parser.add_option("-q", "--quiet", action="store_true", type=None, help="Disable all messages except FATAL ERRORS.")
-        Parser.add_option("-v", "--verbose", action="store_true", type=None, help="Turn on verbose output with informational messages printed, "\
-                                                                                   "including library instances selected, final dependency expression, "\
-                                                                                   "and warning messages, etc.")
-        Parser.add_option("-d", "--debug", action="store", type="int", help="Enable debug messages at specified level.")
-        Parser.add_option("-D", "--define", action="append", type="string", dest="Macros", help="Macro: \"Name [= Value]\".")
+        Parser.add_argument("-s", "--silent", action="store_true", dest="SilentMode",
+                            help="Make use of silent mode of (n)make.")
+        Parser.add_argument("-q", "--quiet", action="store_true", help="Disable all messages except FATAL ERRORS.")
+        Parser.add_argument("-v", "--verbose", action="store_true", help="Turn on verbose output with informational messages printed, "
+                            "including library instances selected, final dependency expression, "
+                            "and warning messages, etc.")
+        Parser.add_argument("-d", "--debug", action="store", type=int, help="Enable debug messages at specified level.")
+        Parser.add_argument("-D", "--define", action="append", type=str,
+                            dest="Macros", help="Macro: \"Name [= Value]\".")
 
-        Parser.add_option("-y", "--report-file", action="store", dest="ReportFile", help="Create/overwrite the report to the specified filename.")
-        Parser.add_option("-Y", "--report-type", action="append", type="choice", choices=['PCD', 'LIBRARY', 'FLASH', 'DEPEX', 'BUILD_FLAGS', 'FIXED_ADDRESS', 'HASH', 'EXECUTION_ORDER'], dest="ReportType", default=[],
-            help="Flags that control the type of build report to generate.  Must be one of: [PCD, LIBRARY, FLASH, DEPEX, BUILD_FLAGS, FIXED_ADDRESS, HASH, EXECUTION_ORDER].  "\
-                 "To specify more than one flag, repeat this option on the command line and the default flag set is [PCD, LIBRARY, FLASH, DEPEX, HASH, BUILD_FLAGS, FIXED_ADDRESS]")
-        Parser.add_option("-F", "--flag", action="store", type="string", dest="Flag",
-            help="Specify the specific option to parse EDK UNI file. Must be one of: [-c, -s]. -c is for EDK framework UNI file, and -s is for EDK UEFI UNI file. "\
-                 "This option can also be specified by setting *_*_*_BUILD_FLAGS in [BuildOptions] section of platform DSC. If they are both specified, this value "\
-                 "will override the setting in [BuildOptions] section of platform DSC.")
-        Parser.add_option("-N", "--no-cache", action="store_true", dest="DisableCache", default=False, help="Disable build cache mechanism")
-        Parser.add_option("--conf", action="store", type="string", dest="ConfDirectory", help="Specify the customized Conf directory.")
-        Parser.add_option("--check-usage", action="store_true", dest="CheckUsage", default=False, help="Check usage content of entries listed in INF file.")
-        Parser.add_option("--ignore-sources", action="store_true", dest="IgnoreSources", default=False, help="Focus to a binary build and ignore all source files")
-        Parser.add_option("--pcd", action="append", dest="OptionPcd", help="Set PCD value by command line. Format: \"PcdName=Value\" ")
-        Parser.add_option("-l", "--cmd-len", action="store", type="int", dest="CommandLength", help="Specify the maximum line length of build command. Default is 4096.")
-        Parser.add_option("--hash", action="store_true", dest="UseHashCache", default=False, help="Enable hash-based caching during build process.")
-        Parser.add_option("--binary-destination", action="store", type="string", dest="BinCacheDest", help="Generate a cache of binary files in the specified directory.")
-        Parser.add_option("--binary-source", action="store", type="string", dest="BinCacheSource", help="Consume a cache of binary files from the specified directory.")
-        Parser.add_option("--genfds-multi-thread", action="store_true", dest="GenfdsMultiThread", default=True, help="Enable GenFds multi thread to generate ffs file.")
-        Parser.add_option("--no-genfds-multi-thread", action="store_true", dest="NoGenfdsMultiThread", default=False, help="Disable GenFds multi thread to generate ffs file.")
-        Parser.add_option("--disable-include-path-check", action="store_true", dest="DisableIncludePathCheck", default=False, help="Disable the include path check for outside of package.")
-        self.BuildOption, self.BuildTarget = Parser.parse_args()
+        Parser.add_argument("-y", "--report-file", action="store", dest="ReportFile",
+                            help="Create/overwrite the report to the specified filename.")
+        Parser.add_argument("-Y", "--report-type", action="append", type=str, dest="ReportType", default=[], choices=['PCD', 'LIBRARY', 'FLASH', 'DEPEX', 'BUILD_FLAGS', 'FIXED_ADDRESS', 'HASH', 'EXECUTION_ORDER'],
+                            help="Flags that control the type of build report to generate. "
+                            "Must be one of: [PCD, LIBRARY, FLASH, DEPEX, BUILD_FLAGS, FIXED_ADDRESS, HASH, EXECUTION_ORDER]. "
+                            "To specify more than one flag, repeat this option on the command line and the default flag set is "
+                            "[PCD, LIBRARY, FLASH, DEPEX, HASH, BUILD_FLAGS, FIXED_ADDRESS]")
+        Parser.add_argument("-F", "--flag", action="store", type=str, dest="Flag", choices=['-c', '-s'],
+                            help="Specify the specific option to parse EDK UNI file. Must be one of: [-c, -s]. "
+                            "-c is for EDK framework UNI file, and -s is for EDK UEFI UNI file. "
+                            "This option can also be specified by setting *_*_*_BUILD_FLAGS in [BuildOptions] section of platform DSC. "
+                            "If they are both specified, this value will override the setting in [BuildOptions] section of platform DSC.")
+        Parser.add_argument("-N", "--no-cache", action="store_true", dest="DisableCache",
+                            help="Disable build cache mechanism")
+        Parser.add_argument("--conf", action="store", type=str, dest="ConfDirectory",
+                            help="Specify the customized Conf directory.")
+        Parser.add_argument("--check-usage", action="store_true", dest="CheckUsage", default=False,
+                            help="Check usage content of entries listed in INF file.")
+        Parser.add_argument("--ignore-sources", action="store_true", dest="IgnoreSources",
+                            help="Focus to a binary build and ignore all source files")
+        Parser.add_argument("--pcd", action="append", dest="OptionPcd",
+                            help="Set PCD value by command line. Format: \"PcdName=Value\" ")
+        Parser.add_argument("-l", "--cmd-len", action="store", type=int, dest="CommandLength",
+                            help="Specify the maximum line length of build command. Default is 4096.")
+        Parser.add_argument("--hash", action="store_true", dest="UseHashCache", default=False,
+                            help="Enable hash-based caching during build process.")
+        Parser.add_argument("--binary-destination", action="store", type=str, dest="BinCacheDest",
+                            help="Generate a cache of binary files in the specified directory.")
+        Parser.add_argument("--binary-source", action="store", type=str, dest="BinCacheSource",
+                            help="Consume a cache of binary files from the specified directory.")
+
+        # WARNING: Redundant Flag. Maybe should be removed
+        Parser.add_argument("--genfds-multi-thread", action="store_true", dest="GenfdsMultiThread",
+                            default=True, help="Enable GenFds multi thread to generate ffs file.")
+
+        Parser.add_argument("--no-genfds-multi-thread", action="store_true", dest="NoGenfdsMultiThread",
+                            help="Disable GenFds multi thread to generate ffs file.")
+        Parser.add_argument("--disable-include-path-check", action="store_true", dest="DisableIncludePathCheck",
+                            help="Disable the include path check for outside of package.")
+
+        self.BuildArguments = Parser.parse_args()

--- a/edk2basetools/build/buildoptions.py
+++ b/edk2basetools/build/buildoptions.py
@@ -12,8 +12,9 @@
 from edk2basetools.Common.BuildVersion import gBUILD_VERSION
 from argparse import ArgumentParser
 VersionNumber = "0.60" + ' ' + gBUILD_VERSION
-__version__ = "%prog Version " + VersionNumber
+__version__ = "%(prog)s Version " + VersionNumber
 __copyright__ = "Copyright (c) 2007 - 2018, Intel Corporation  All rights reserved."
+__usage__ = "%(prog)s [options] TARGET"
 
 
 class MyOptionParser():
@@ -29,7 +30,7 @@ class MyOptionParser():
             self.BuildArguments = None
 
     def GetOption(self):
-        Parser = ArgumentParser(description=__copyright__, prog="edk2_build")
+        Parser = ArgumentParser(description=__copyright__, prog="edk2_build", usage=__usage__)
         Parser.add_argument("Target", metavar="TARGET", type=str, choices=['all', 'genc', 'genmake', 'modules', 'libraries', 'fds', 'clean', 'cleanall', 'cleanlib',
                             'run'], help="target is one of the list: all, fds, genc, genmake, clean, cleanall, cleanlib, modules, libraries, run", default="all", nargs='?')
         Parser.add_argument('--version', action='version', version=__version__)


### PR DESCRIPTION
optparse has been deprecated since Python 3.2 and Python 2.7 and has been replaced with argparse.

Initially, I was going to submit patches to the mailing list but the Readme states that this project uses Github PRs, so here we go.

The other uses of OptParse seem to have somewhat broken CLI, so I have left them alone for now:
1. `edk2basetools/Eot/EotMain.py`
2.  `edk2basetools/UPT/UPT.py`
3. `edk2basetools/GenFds/GenFds.py`
4. `edk2basetools/Ecc/EccMain.py`
5. `edk2basetools/BPDG/BPDG.py`

Signed-off-by: Ayush Singh <ayushdevel1325@gmail.com>