### PR TITLE
BaseTools: Remove RVCT support

### DIFF
--- a/edk2basetools/AutoGen/BuildEngine.py
+++ b/edk2basetools/AutoGen/BuildEngine.py
@@ -317,7 +317,7 @@ class BuildRule:
     #   @param  LineIndex           The line number from which the parsing will begin
     #   @param  SupportedFamily     The list of supported tool chain families
     #
-    def __init__(self, File=None, Content=None, LineIndex=0, SupportedFamily=[TAB_COMPILER_MSFT, "INTEL", "GCC", "RVCT"]):
+    def __init__(self, File=None, Content=None, LineIndex=0, SupportedFamily=[TAB_COMPILER_MSFT, "INTEL", "GCC"]):
         self.RuleFile = File
         # Read build rules from file if it's not none
         if File is not None:

--- a/edk2basetools/AutoGen/GenMake.py
+++ b/edk2basetools/AutoGen/GenMake.py
@@ -166,7 +166,7 @@ class BuildFile(object):
         GMAKE_FILETYPE :   "include"
     }
 
-    _INC_FLAG_ = {TAB_COMPILER_MSFT : "/I", "GCC" : "-I", "INTEL" : "-I", "RVCT" : "-I", "NASM" : "-I"}
+    _INC_FLAG_ = {TAB_COMPILER_MSFT : "/I", "GCC" : "-I", "INTEL" : "-I", "NASM" : "-I"}
 
     ## Constructor of BuildFile
     #

--- a/edk2basetools/AutoGen/ModuleAutoGen.py
+++ b/edk2basetools/AutoGen/ModuleAutoGen.py
@@ -32,7 +32,7 @@ import tempfile
 ## Mapping Makefile type
 gMakeTypeMap = {TAB_COMPILER_MSFT:"nmake", "GCC":"gmake"}
 #
-# Regular expression for finding Include Directories, the difference between MSFT and INTEL/GCC/RVCT
+# Regular expression for finding Include Directories, the difference between MSFT and INTEL/GCC
 # is the former use /I , the Latter used -I to specify include directories
 #
 gBuildOptIncludePatternMsft = re.compile(r"(?:.*?)/I[ \t]*([^ ]*)", re.MULTILINE | re.DOTALL)
@@ -684,12 +684,12 @@ class ModuleAutoGen(AutoGen):
     @cached_property
     def BuildOptionIncPathList(self):
         #
-        # Regular expression for finding Include Directories, the difference between MSFT and INTEL/GCC/RVCT
+        # Regular expression for finding Include Directories, the difference between MSFT and INTEL/GCC
         # is the former use /I , the Latter used -I to specify include directories
         #
         if self.PlatformInfo.ToolChainFamily in (TAB_COMPILER_MSFT):
             BuildOptIncludeRegEx = gBuildOptIncludePatternMsft
-        elif self.PlatformInfo.ToolChainFamily in ('INTEL', 'GCC', 'RVCT'):
+        elif self.PlatformInfo.ToolChainFamily in ('INTEL', 'GCC'):
             BuildOptIncludeRegEx = gBuildOptIncludePatternOther
         else:
             #
@@ -704,16 +704,7 @@ class ModuleAutoGen(AutoGen):
             except KeyError:
                 FlagOption = ''
 
-            if self.ToolChainFamily != 'RVCT':
-                IncPathList = [NormPath(Path, self.Macros) for Path in BuildOptIncludeRegEx.findall(FlagOption)]
-            else:
-                #
-                # RVCT may specify a list of directory seperated by commas
-                #
-                IncPathList = []
-                for Path in BuildOptIncludeRegEx.findall(FlagOption):
-                    PathList = GetSplitList(Path, TAB_COMMA_SPLIT)
-                    IncPathList.extend(NormPath(PathEntry, self.Macros) for PathEntry in PathList)
+            IncPathList = [NormPath(Path, self.Macros) for Path in BuildOptIncludeRegEx.findall(FlagOption)]
 
             #
             # EDK II modules must not reference header files outside of the packages they depend on or

--- a/edk2basetools/UPT/Library/DataType.py
+++ b/edk2basetools/UPT/Library/DataType.py
@@ -939,7 +939,6 @@ MODEL_META_DATA_CONDITIONAL_STATEMENT_ENDIF = 5014
 TOOL_FAMILY_LIST = ["MSFT",
                     "INTEL",
                     "GCC",
-                    "RVCT"
                     ]
 
 TYPE_HOB_SECTION = 'HOB'


### PR DESCRIPTION
RVCT is obsolete and no longer used.
Remove support for it.

Signed-off-by: Rebecca Cran <quic_rcran@quicinc.com>
Reviewed-by: Ard Biesheuvel <ardb@kernel.org>