### PR TITLE
BaseTools: Fix dependency issue in PcdValueInit

### DIFF
--- a/edk2basetools/Workspace/DscBuildData.py
+++ b/edk2basetools/Workspace/DscBuildData.py
@@ -97,7 +97,8 @@ PcdMakefileEnd = '''
 
 AppTarget = '''
 all: $(APPFILE)
-$(APPFILE): $(OBJECTS)
+$(APPLICATION): $(OBJECTS)
+$(APPFILE): $(APPLICATION)
 %s
 '''
 


### PR DESCRIPTION
The generated Makefile was missing a dependency.  This resulted in a
build-time race condition if the recursive make is multi-threaded and
shares job control.

Signed-off-by: Jake Garver <jake@nvidia.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>