### PR TITLE
Enable Integration tests

### DIFF
--- a/integration_test/.gitignore
+++ b/integration_test/.gitignore
@@ -1,0 +1,5 @@
+/test
+/report
+stderr.txt
+stdout.txt
+/edk2/

--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -1,0 +1,119 @@
+*** Settings ***
+Documentation     A shared set of common keywords for stuart operations and git operations
+#
+# Copyright (c), Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+Library  Process
+Library  OperatingSystem
+
+# Suite Setup
+
+*** Variables ***
+
+#Test output location
+${TEST_OUTPUT}          ${TEST_OUTPUT_BASE}
+
+*** Keywords ***
+
+### Git operations ###
+Clone the git repo
+    [Arguments]    ${git_url}   ${ws_name}
+
+    Log To console    cloning ${git_url} to ${TEST_OUTPUT}
+    ${result}=  Run Process       git   clone   ${git_url}   ${ws_name}
+    ...  cwd=${TEST_OUTPUT}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+
+    ${result}=  Run Process  git  fetch  --all  --prune
+    ...  cwd=${TEST_OUTPUT}${/}${ws_name}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Reset git repo to default branch
+    [Arguments]     ${ws}  ${default_branch_name}
+
+    # checkout remote tag for origin/<default branch>
+    ${result}=  Run Process  git  checkout  origin/${default_branch_name}
+    ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # clean non ignored files quietly to avoid log overflow
+    ${result}=  Run Process  git  clean  -qfd  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # reset to restore files
+    ${result}=  Run Process  git  reset  --hard
+    ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Get default branch from remote
+    [Arguments]     ${ws}
+
+    # Set origin head to auto
+    ${result}=  Run Process  git  remote  set-head  origin  --auto
+    ...  cwd=${ws}
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # get the head
+    ${result}=  Run Process  git  rev-parse  --abbrev-ref  origin/HEAD
+    ...  cwd=${ws}
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # Strip off origin/ from the branch because all other commands
+    # add the remote name.
+    ${branch}=  Get Substring  ${result.stdout}  7
+
+    [Return]  ${branch}
+
+### Stuart operations ###
+Stuart setup
+    [Arguments]  ${setting_file}  ${arch}  ${target}  ${packages}  ${tool_chain}  ${ws}
+    Log to console  Stuart Setup
+    ${result}=   Run Process    stuart_setup
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  -t  ${target}  -p  ${packages}  TARGET\=${target}
+    ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Stuart update
+    [Arguments]  ${setting_file}  ${arch}  ${target}  ${packages}  ${tool_chain}  ${ws}
+    Log to console  Stuart Update
+    ${result}=   Run Process    stuart_update
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  -t  ${target}  -p  ${packages}  TARGET\=${target}
+    ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Stuart platform build
+    [Arguments]  ${setting_file}  ${arch}  ${target}  ${tool_chain}  ${ws}
+    Log to console  Stuart Build
+    ${result}=   Run Process    stuart_build
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}
+    ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Stuart platform run
+    [Arguments]  ${setting_file}  ${arch}  ${target}  ${tool_chain}  ${addtional_flags}  ${ws}
+    Log to console  Stuart Build Run
+    ${result}=   Run Process    stuart_build
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}  --FlashOnly  ${addtional_flags}
+    ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+### Edk2 BaseTools Build operations ###
+Build BaseTools
+    [Arguments]  ${tool_chain}  ${ws}
+    Log to console  Compile basetools
+    ${result}=   Run Process    python
+    ...  BaseTools/Edk2ToolsBuild.py  -t  ${tool_chain}
+    ...  cwd=${ws}  shell=True  stdout=stdout.txt  stderr=stderr.txt
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0

--- a/integration_test/azure-pipelines/robot-integration-test.yml
+++ b/integration_test/azure-pipelines/robot-integration-test.yml
@@ -1,0 +1,101 @@
+##
+# Azure Pipeline integration test using robot framework
+# and edk2 / Project Mu public repositories
+#
+
+# Copyright (c) 2019, Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+jobs:
+- job: Integration_Test
+
+  #Use matrix to speed up the build process
+  strategy:
+    matrix:
+      EDK2_VS2019:
+        Tag: 'Windows'
+        Image: 'windows-2019'
+      EDK2_GCC5:
+        Tag: 'Ubuntu'
+        Image: 'ubuntu-18.04'
+
+  workspace:
+    clean: all
+
+  pool:
+    vmImage: $(Image)
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.10.x'
+      architecture: 'x64'
+
+  - script: pip install --upgrade -r requirements.txt
+    displayName: 'Install requirements'
+
+  - script: pip install --upgrade -r integration_test/pip-requirements.txt
+    displayName: 'Install Integration test requirements'
+
+  - script: pip install -e .
+    displayName: 'Install from Source'
+
+  - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+    displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
+    condition: contains(variables.Tag, 'Windows')
+  
+  - script: sudo dpkg --add-architecture i386
+    displayName: EmulatorPkg - Add i386 Arch
+    condition: contains(variables.Tag, 'Ubuntu')
+
+  - script: sudo apt-get update
+    displayName: Update for dependencies
+    condition: contains(variables.Tag, 'Ubuntu')
+
+  - script: sudo apt-get install uuid-dev
+    displayName: Install General dependencies
+    condition: contains(variables.Tag, 'Ubuntu')
+
+  - script: sudo apt-get install libc6-dev:i386 libx11-dev:i386 libxext-dev:i386 lib32gcc-7-dev
+    displayName: EmulatorPkg - Install dependencies
+    condition: contains(variables.Tag, 'Ubuntu')
+
+  - script: git config --global user.email "you@example.com"
+    displayName: Configure git user user.email
+
+  - script: git config --global user.name "Your Name"
+    displayName: Configure git user user.name
+
+  - script: python -m robot.run -v TEST_OUTPUT_BASE:$(Build.BinariesDirectory) -d report --xunit xunittestresults.xml --include $(Tag) -L TRACE .
+    displayName: 'Run Robot Tests'
+    workingDirectory: "integration_test"
+
+  # Copy the build logs to the artifact staging directory
+  - task: CopyFiles@2
+    displayName: "Copy logs"
+    inputs:
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+      SourceFolder: 'integration_test/report'
+      contents: |
+        log.html
+        output.xml
+        report.html
+      flattenFolders: true
+    condition: succeededOrFailed()
+
+  # Publish build artifacts to Azure Artifacts/TFS or a file share
+  - task: PublishBuildArtifacts@1
+    continueOnError: true
+    displayName: "Publish logs"
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'Logs $(System.JobName)'
+    condition: succeededOrFailed()
+
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: xunittestresults.xml
+      searchFolder: 'integration_test/report'
+    condition: succeededOrFailed()
+    displayName: 'Publish Test Results'

--- a/integration_test/edk2_platform_Ubuntu.robot
+++ b/integration_test/edk2_platform_Ubuntu.robot
@@ -1,0 +1,234 @@
+*** Settings ***
+Documentation     A test suite to test Platform CI on edk2 repo
+#
+# Copyright (c), Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+Library  Process
+Library  OperatingSystem
+Library  String
+
+Resource  Shared_Keywords.robot
+
+Suite Setup  One time setup  ${repo_url}  ${ws_dir}
+
+# Suite Setup
+
+*** Variables ***
+${repo_url}           https://github.com/tianocore/edk2.git
+${default_branch}     not_yet_set
+${ws_dir}             edk2
+${ws_root}            ${TEST_OUTPUT}${/}${ws_dir}
+${tool_chain}         GCC5
+
+
+*** Keywords ***
+One time setup
+    [Arguments]  ${url}  ${folder}
+    ## Dump pip versions
+    ${result}=   Run Process    python  -m  pip   list  shell=True
+    Log  ${result.stdout}
+
+    ## Make output directory if doesn't already exist
+    Create Directory  ${TEST_OUTPUT}
+
+    ## Clone repo
+    Run Keyword  Clone the git repo  ${url}  ${folder}
+
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
+
+
+*** Test Cases ***
+Run Edk2 Ovmf IA32 DEBUG
+    [Documentation]  This test will run IA32 DEBUG build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  IA32  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Ovmf IA32 RELEASE
+    [Documentation]  This test will run IA32 RELEASE build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  IA32  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Ovmf X64 DEBUG
+    [Documentation]  This test will run X64 DEBUG build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  X64  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Ovmf X64 RELEASE
+    [Documentation]  This test will run X64 RELEASE build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  X64  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Emulator IA32 DEBUG
+    [Documentation]  This test will run IA32 DEBUG build for EmulatorPkg
+    [Tags]           PlatformCI  EmulatorPkg  IA32  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Emulator IA32 RELEASE
+    [Documentation]  This test will run IA32 RELEASE build for EmulatorPkg
+    [Tags]           PlatformCI EmulatorPkg  IA32  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Emulator X64 DEBUG
+    [Documentation]  This test will run X64 DEBUG build for EmulatorPkg
+    [Tags]           PlatformCI EmulatorPkg  X64  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 Emulator X64 RELEASE
+    [Documentation]  This test will run X64 RELEASE build for EmulatorPkg
+    [Tags]           PlatformCI EmulatorPkg  X64  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 ArmVirt ARM DEBUG
+    [Documentation]  This test will run ARM DEBUG build for ArmVirtPkg
+    [Tags]           PlatformCI  ArmVirtPkg  ARM  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  ARM
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  ArmVirtPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 ArmVirt ARM RELEASE
+    [Documentation]  This test will run ARM RELEASE build for ArmVirtPkg
+    [Tags]           PlatformCI  ArmVirtPkg  ARM  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  ARM
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  ArmVirtPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 ArmVirt AARCH64 DEBUG
+    [Documentation]  This test will run AARCH64 DEBUG build for ArmVirtPkg
+    [Tags]           PlatformCI  ArmVirtPkg  AARCH64  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  AARCH64
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  ArmVirtPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+
+Run Edk2 ArmVirt AARCH64 RELEASE
+    [Documentation]  This test will run AARCH64 RELEASE build for ArmVirtPkg
+    [Tags]           PlatformCI  ArmVirtPkg  AARCH64  GCC5  Ubuntu  Qemu  Edk2
+    ${arch}=              Set Variable  AARCH64
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  ArmVirtPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}

--- a/integration_test/edk2_platform_Windows.robot
+++ b/integration_test/edk2_platform_Windows.robot
@@ -1,0 +1,178 @@
+*** Settings ***
+Documentation     A test suite to test Platform CI on edk2 repo
+#
+# Copyright (c), Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+Library  Process
+Library  OperatingSystem
+Library  String
+
+Resource  Shared_Keywords.robot
+
+Suite Setup  One time setup  ${repo_url}  ${ws_dir}
+
+# Suite Setup
+
+*** Variables ***
+${repo_url}           https://github.com/tianocore/edk2.git
+${default_branch}     not_yet_set
+${ws_dir}             edk2
+${ws_root}            ${TEST_OUTPUT}${/}${ws_dir}
+${tool_chain}         VS2019
+
+
+*** Keywords ***
+One time setup
+    [Arguments]  ${url}  ${folder}
+    ## Dump pip versions
+    ${result}=   Run Process    python  -m  pip   list  shell=True
+    Log  ${result.stdout}
+
+    ## Make output directory if doesn't already exist
+    Create Directory  ${TEST_OUTPUT}
+
+    ## Clone repo
+    Run Keyword  Clone the git repo  ${url}  ${folder}
+
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
+
+
+*** Test Cases ***
+Run Edk2 Ovmf IA32 DEBUG
+    [Documentation]  This test will run IA32 DEBUG build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  IA32  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Ovmf IA32 RELEASE
+    [Documentation]  This test will run IA32 RELEASE build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  IA32  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Ovmf X64 DEBUG
+    [Documentation]  This test will run X64 DEBUG build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  X64  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Ovmf X64 RELEASE
+    [Documentation]  This test will run X64 RELEASE build for OvmfPkg
+    [Tags]           PlatformCI  OvmfPkg  X64  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  OvmfPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Emulator IA32 DEBUG
+    [Documentation]  This test will run IA32 DEBUG build for EmulatorPkg
+    [Tags]           PlatformCI  EmulatorPkg  IA32  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Emulator IA32 RELEASE
+    [Documentation]  This test will run IA32 RELEASE build for EmulatorPkg
+    [Tags]           PlatformCI EmulatorPkg  IA32  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  IA32
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Emulator X64 DEBUG
+    [Documentation]  This test will run X64 DEBUG build for EmulatorPkg
+    [Tags]           PlatformCI EmulatorPkg  X64  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  DEBUG
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}
+
+Run Edk2 Emulator X64 RELEASE
+    [Documentation]  This test will run X64 RELEASE build for EmulatorPkg
+    [Tags]           PlatformCI EmulatorPkg  X64  VS2019  Windows  Qemu  Edk2
+    ${arch}=              Set Variable  X64
+    ${target}=            Set Variable  RELEASE
+    ${package}=           Set Variable  EmulatorPkg
+    ${ci_file}=           Set Variable  ${package}${/}PlatformCI${/}PlatformBuild.py
+
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+
+    Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
+    Build BaseTools        ${tool_chain}  ${ws_root}
+    Stuart platform build  ${ci_file}  ${arch}  ${target}  ${tool_chain}  ${ws_root}
+    Stuart platform run    ${ci_file}  ${arch}  ${target}  ${tool_chain}  MAKE_STARTUP_NSH\=TRUE  ${ws_root}

--- a/integration_test/pip-requirements.txt
+++ b/integration_test/pip-requirements.txt
@@ -1,0 +1,4 @@
+edk2-pytool-library==0.11.2 # Match edk2
+edk2-pytool-extensions~=0.16.0 # Match edk2
+robotframework
+regex 


### PR DESCRIPTION
As mentioned in #53, this PR is waiting for an update to the PlatformBuild.py files for OvmfPkg, ArmVirtPkg, and EmulatorPkg before this PR is merged.

The integration tests currently only run platform builds (IA32/X64, DEBUG/RELEASE). Please let me know if there are tools other than build that use BaseTools that you wish integration tests to be ran on, and I will add them to this PR.