### PR TITLE
BaseTools: Remove duplicated words in Python tools

### DIFF
--- a/edk2basetools/Ecc/EccToolError.py
+++ b/edk2basetools/Ecc/EccToolError.py
@@ -186,7 +186,7 @@ gEccErrorMessage = {
     ERROR_META_DATA_FILE_CHECK_BINARY_INF_IN_FDF : "An INF file is specified in the FDF file, but not in the DSC file, therefore the INF file must be for a Binary module only",
     ERROR_META_DATA_FILE_CHECK_PCD_DUPLICATE : "Duplicate PCDs found",
     ERROR_META_DATA_FILE_CHECK_PCD_FLASH : "PCD settings in the FDF file should only be related to flash",
-    ERROR_META_DATA_FILE_CHECK_PCD_NO_USE : "There should be no PCDs declared in INF files that are not specified in in either a DSC or FDF file",
+    ERROR_META_DATA_FILE_CHECK_PCD_NO_USE : "There should be no PCDs declared in INF files that are not specified in either a DSC or FDF file",
     ERROR_META_DATA_FILE_CHECK_DUPLICATE_GUID : "Duplicate GUID found",
     ERROR_META_DATA_FILE_CHECK_DUPLICATE_PROTOCOL : "Duplicate PROTOCOL found",
     ERROR_META_DATA_FILE_CHECK_DUPLICATE_PPI : "Duplicate PPI found",

--- a/edk2basetools/build/build.py
+++ b/edk2basetools/build/build.py
@@ -207,7 +207,7 @@ class MakeSubProc(Popen):
 #
 # This method will call subprocess.Popen to execute an external program with
 # given options in specified directory. Because of the dead-lock issue during
-# redirecting output of the external program, threads are used to to do the
+# redirecting output of the external program, threads are used to do the
 # redirection work.
 #
 # @param  Command               A list or string containing the call of the program


### PR DESCRIPTION
In an effort to clean the documentation of the above package, remove duplicated words.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>
Signed-off-by: Pierre Gondois <pierre.gondois@arm.com>