### PR TITLE
BaseTools: Add support for SUBTYPE_GUID section generation

### DIFF
--- a/edk2basetools/CommonDataClass/FdfClass.py
+++ b/edk2basetools/CommonDataClass/FdfClass.py
@@ -190,6 +190,18 @@ class GuidSectionClassObject (SectionClassObject) :
         self.FvParentAddr = None
         self.IncludeFvSection = False
 
+## SubType GUID section data in FDF
+#
+#
+class SubTypeGuidSectionClassObject (SectionClassObject) :
+    ## The constructor
+    #
+    #   @param  self        The object pointer
+    #
+    def __init__(self):
+        SectionClassObject.__init__(self)
+        self.SubTypeGuid = None
+
 ## UI section data in FDF
 #
 #

--- a/edk2basetools/GenFds/FdfParser.py
+++ b/edk2basetools/GenFds/FdfParser.py
@@ -42,6 +42,7 @@ from .DataSection import DataSection
 from .DepexSection import DepexSection
 from .CompressSection import CompressSection
 from .GuidSection import GuidSection
+from .SubTypeGuidSection import SubTypeGuidSection
 from .Capsule import EFI_CERT_TYPE_PKCS7_GUID, EFI_CERT_TYPE_RSA2048_SHA256_GUID, Capsule
 from .CapsuleData import CapsuleFfs, CapsulePayload, CapsuleFv, CapsuleFd, CapsuleAnyFile, CapsuleAfile
 from .RuleComplexFile import RuleComplexFile
@@ -2891,6 +2892,27 @@ class FdfParser:
 
             DepexSectionObj.Expression = self._SkippedChars.rstrip(T_CHAR_BRACE_R)
             Obj.SectionList.append(DepexSectionObj)
+
+        elif self._IsKeyword("SUBTYPE_GUID"):
+            if AlignValue == 'Auto':
+                raise Warning("Auto alignment can only be used in PE32 or TE section ", self.FileName, self.CurrentLineNumber)
+            SubTypeGuidValue = None
+            if not self._GetNextGuid():
+                raise Warning.Expected("GUID", self.FileName, self.CurrentLineNumber)
+            else:
+                SubTypeGuidValue = self._Token
+
+            if not self._IsToken(TAB_EQUAL_SPLIT):
+                raise Warning.ExpectedEquals(self.FileName, self.CurrentLineNumber)
+            if not self._GetNextToken():
+                raise Warning.Expected("section file path", self.FileName, self.CurrentLineNumber)
+            FileName = self._Token
+
+            SubTypeGuidSectionObj = SubTypeGuidSection()
+            SubTypeGuidSectionObj.Alignment = AlignValue
+            SubTypeGuidSectionObj.SubTypeGuid = SubTypeGuidValue
+            SubTypeGuidSectionObj.SectFileName = FileName
+            Obj.SectionList.append(SubTypeGuidSectionObj)
 
         else:
             if not self._GetNextWord():

--- a/edk2basetools/GenFds/SubTypeGuidSection.py
+++ b/edk2basetools/GenFds/SubTypeGuidSection.py
@@ -1,0 +1,76 @@
+## @file
+# process Subtype GUIDed section generation
+#
+#  Copyright (c) 2022, Konstantin Aladyshev <aladyshev22@gmail.com>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+##
+# Import Modules
+#
+from __future__ import absolute_import
+from . import Section
+import subprocess
+from .Ffs import SectionSuffix
+import Common.LongFilePathOs as os
+from .GenFdsGlobalVariable import GenFdsGlobalVariable
+from .GenFdsGlobalVariable import FindExtendTool
+from CommonDataClass.FdfClass import SubTypeGuidSectionClassObject
+import sys
+from Common import EdkLogger
+from Common.BuildToolError import *
+from .FvImageSection import FvImageSection
+from Common.LongFilePathSupport import OpenLongFilePath as open
+from Common.DataType import *
+
+## generate SubType GUIDed section
+#
+#
+class SubTypeGuidSection(SubTypeGuidSectionClassObject) :
+
+    ## The constructor
+    #
+    #   @param  self        The object pointer
+    #
+    def __init__(self):
+        SubTypeGuidSectionClassObject.__init__(self)
+
+    ## GenSection() method
+    #
+    #   Generate GUIDed section
+    #
+    #   @param  self        The object pointer
+    #   @param  OutputPath  Where to place output file
+    #   @param  ModuleName  Which module this section belongs to
+    #   @param  SecNum      Index of section
+    #   @param  KeyStringList  Filter for inputs of section generation
+    #   @param  FfsInf      FfsInfStatement object that contains this section data
+    #   @param  Dict        dictionary contains macro and its value
+    #   @retval tuple       (Generated file name, section alignment)
+    #
+    def GenSection(self, OutputPath, ModuleName, SecNum, KeyStringList, FfsInf=None, Dict=None, IsMakefile=False):
+        #
+        # Generate all section
+        #
+        self.KeyStringList = KeyStringList
+        self.CurrentArchList = GenFdsGlobalVariable.ArchList
+        if FfsInf is not None:
+            self.Alignment = FfsInf.__ExtendMacro__(self.Alignment)
+            self.SubTypeGuid = FfsInf.__ExtendMacro__(self.SubTypeGuid)
+            self.SectionType = FfsInf.__ExtendMacro__(self.SectionType)
+            self.CurrentArchList = [FfsInf.CurrentArch]
+
+        if Dict is None:
+            Dict = {}
+
+        self.SectFileName = GenFdsGlobalVariable.ReplaceWorkspaceMacro(self.SectFileName)
+        self.SectFileName = GenFdsGlobalVariable.MacroExtend(self.SectFileName, Dict)
+
+        OutputFile = os.path.join(OutputPath, ModuleName + SUP_MODULE_SEC + SecNum + SectionSuffix.get("SUBTYPE_GUID"))
+        GenFdsGlobalVariable.GenerateSection(OutputFile, [self.SectFileName], 'EFI_SECTION_FREEFORM_SUBTYPE_GUID', Guid=self.SubTypeGuid, IsMakefile=IsMakefile)
+
+        OutputFileList = []
+        OutputFileList.append(OutputFile)
+        return OutputFileList, self.Alignment
+


### PR DESCRIPTION
EFI_SECTION_FREEFORM_SUBTYPE_GUID is a leaf section type that contains a single EFI_GUID in the header to describe the raw data. Currently is is not possible to generate such section. This patch adds initial support for the generation of such sections. The added syntax for this type of section corresponds to EDKII "[FV] section" documentation from the FDF Specification:
```
SECTION SUBTYPE_GUID <GUID> = <File>
```

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>