### PR TITLE
BaseTools/GenFds: Correct file type set for the PIC section

### DIFF
--- a/edk2basetools/GenFds/FdfParser.py
+++ b/edk2basetools/GenFds/FdfParser.py
@@ -4018,7 +4018,7 @@ class FdfParser:
             if FileType not in {BINARY_FILE_TYPE_PE32, "SEC_PE32"}:
                 raise Warning(WarningString % FileType, self.FileName, self.CurrentLineNumber)
         elif SectionType == BINARY_FILE_TYPE_PIC:
-            if FileType not in {BINARY_FILE_TYPE_PIC, BINARY_FILE_TYPE_PIC}:
+            if FileType not in {BINARY_FILE_TYPE_PIC, "SEC_PIC"}:
                 raise Warning(WarningString % FileType, self.FileName, self.CurrentLineNumber)
         elif SectionType == BINARY_FILE_TYPE_TE:
             if FileType not in {BINARY_FILE_TYPE_TE, "SEC_TE"}:


### PR DESCRIPTION
Corrently the set of file types for the PIC section contains two duplicate values.
Replace the duplicate value with the correct one to fix the issue.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>