### PR TITLE
BaseTools: Add missing spaces for PCD expression values in AutoGenC

### DIFF
--- a/edk2basetools/Common/Expression.py
+++ b/edk2basetools/Common/Expression.py
@@ -1026,7 +1026,7 @@ class ValueExpressionEx(ValueExpression):
                                     Size += ItemSize
 
                             if Size > 0:
-                                PcdValue = '{' + ','.join(AllPcdValueList) + '}'
+                                PcdValue = '{' + ', '.join(AllPcdValueList) + '}'
                         else:
                             raise  BadExpression("Type: %s, Value: %s, %s"%(self.PcdType, PcdValue, Value))
 


### PR DESCRIPTION
Currently the PCD values calculated from the expressions have different formating from the simple byte arrays in AutoGenC.

Example:
The following definition in DEC:
gTokenSpaceGuid.PcdArray|{0x44, 0x33, 0x22, 0x11}|VOID*|0x55555555 gTokenSpaceGuid.PcdArrayByExpression|{UINT32(0x11223344)}|VOID*|0x66666666

Produces these strings in AutoGenC:
<...> _gPcd_<...>_PcdArray[4] = {0x44, 0x33, 0x22, 0x11}; <...> _gPcd_<...>_PcdArrayByExpression[4] = {0x44,0x33,0x22,0x11};

Add missing space character between the array elements to unify PCD value formatting.

Signed-off-by: Konstantin Aladyshev <aladyshev22@gmail.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
Reviewed-by: Bob Feng <bob.c.feng@intel.com>