### PR TITLE
GenFds/SubTypeGuidSection.py: Fully qualify reference to Common

### DIFF
--- a/edk2basetools/GenFds/SubTypeGuidSection.py
+++ b/edk2basetools/GenFds/SubTypeGuidSection.py
@@ -13,16 +13,16 @@ from __future__ import absolute_import
 from . import Section
 import subprocess
 from .Ffs import SectionSuffix
-import Common.LongFilePathOs as os
+import edk2basetools.Common.LongFilePathOs as os
 from .GenFdsGlobalVariable import GenFdsGlobalVariable
 from .GenFdsGlobalVariable import FindExtendTool
-from CommonDataClass.FdfClass import SubTypeGuidSectionClassObject
+from edk2basetools.CommonDataClass.FdfClass import SubTypeGuidSectionClassObject
 import sys
-from Common import EdkLogger
-from Common.BuildToolError import *
+from edk2basetools.Common import EdkLogger
+from edk2basetools.Common.BuildToolError import *
 from .FvImageSection import FvImageSection
-from Common.LongFilePathSupport import OpenLongFilePath as open
-from Common.DataType import *
+from edk2basetools.Common.LongFilePathSupport import OpenLongFilePath as open
+from edk2basetools.Common.DataType import *
 
 ## generate SubType GUIDed section
 #


### PR DESCRIPTION
In some cases, building EDK2 using the PIP version of the edk2 basetools fails with

  $ build -p OvmfPkg/OvmfPkgX64.dsc -a X64
  Traceback (most recent call last):
    File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
      exec(code, run_globals)
    File "/home/ard/.local/lib/python3.10/site-packages/edk2basetools/build/build.py",
  line 34, in <module>
      from edk2basetools.AutoGen.WorkspaceAutoGen import WorkspaceAutoGen
    File "/home/ard/.local/lib/python3.10/site-packages/edk2basetools/AutoGen/WorkspaceAutoGen.py",
  line 15, in <module>
      from edk2basetools.GenFds.FdfParser import FdfParser
    File "/home/ard/.local/lib/python3.10/site-packages/edk2basetools/GenFds/FdfParser.py",
  line 45, in <module>
      from .SubTypeGuidSection import SubTypeGuidSection
    File "/home/ard/.local/lib/python3.10/site-packages/edk2basetools/GenFds/SubTypeGuidSection.py",
  line 16, in <module>
      import Common.LongFilePathOs as os
  ModuleNotFoundError: No module named 'Common'

The cause seems to be the fact that unlike other modules, GenFds/SubTypeGuidSection.py does not fully qualify the reference to Common, and lacks the edk2basetools. prefix. So add that.

Signed-off-by: Ard Biesheuvel <ardb@kernel.org>