### PR TITLE
Fix the author email in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setuptools.setup(
     name=PACKAGE_NAME,
     version=version,
     author="Tianocore Edk2-BaseTool team",
-    author_email="edk2-bugs@lists.01.org",
+    author_email="devel@edk2.groups.io",
     description="Python BaseTools supporting UEFI EDK2 firmware development",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The project no longer uses lists.01.org. Since bugs@edk2.groups.io is an automated list that few likely monitor for messages, set the email address to devel@edk2.groups.io.

Issue: #91