### PR TITLE
DscBuildData.py: set CC_FLAGS2 when running on Windows

### DIFF
--- a/edk2basetools/Workspace/DscBuildData.py
+++ b/edk2basetools/Workspace/DscBuildData.py
@@ -2895,6 +2895,7 @@ class DscBuildData(PlatformBuildClassObject):
         CC_FLAGS2 = LinuxCFLAGS2
         if sys.platform == "win32":
             CC_FLAGS = WindowsCFLAGS
+            CC_FLAGS2 = WindowsCFLAGS
         BuildOptions = OrderedDict()
         for Options in self.BuildOptions:
             if Options[2] != EDKII_NAME:


### PR DESCRIPTION
CC_FLAGS2 also needs to be set when running on Windows, otherwise the wrong line is added and nmake fails when building using Visual Studio.