### PR TITLE
Remove the BUILD_CFLAGS compatibility code in Workspace/DscBuildData.py

### DIFF
--- a/edk2basetools/Workspace/DscBuildData.py
+++ b/edk2basetools/Workspace/DscBuildData.py
@@ -90,7 +90,6 @@ PcdMakefileHeader = '''
 
 WindowsCFLAGS = 'CFLAGS = $(CFLAGS) /wd4200 /wd4034 /wd4101 '
 LinuxCFLAGS = 'CFLAGS += -Wno-pointer-to-int-cast -Wno-unused-variable '
-LinuxCFLAGS2 = 'BUILD_CFLAGS += -Wno-pointer-to-int-cast -Wno-unused-variable '
 PcdMakefileEnd = '''
 !INCLUDE $(BASE_TOOLS_PATH)\Source\C\Makefiles\ms.common
 !INCLUDE $(BASE_TOOLS_PATH)\Source\C\Makefiles\ms.app
@@ -2892,10 +2891,8 @@ class DscBuildData(PlatformBuildClassObject):
         MakeApp = MakeApp + '\n'
 
         CC_FLAGS = LinuxCFLAGS
-        CC_FLAGS2 = LinuxCFLAGS2
         if sys.platform == "win32":
             CC_FLAGS = WindowsCFLAGS
-            CC_FLAGS2 = WindowsCFLAGS
         BuildOptions = OrderedDict()
         for Options in self.BuildOptions:
             if Options[2] != EDKII_NAME:
@@ -2929,9 +2926,7 @@ class DscBuildData(PlatformBuildClassObject):
             ValueList = [item for item in BuildOptions['COMMON'] if item.startswith((r"/U","-U"))]
             ValueList.extend([item for item in BuildOptions['COMMON'] if item.startswith((r"/D", "-D"))])
             CC_FLAGS += " ".join(ValueList)
-            CC_FLAGS2 += " ".join(ValueList)
         MakeApp += CC_FLAGS
-        MakeApp += "\n" + CC_FLAGS2
 
         if sys.platform == "win32":
             MakeApp = MakeApp + PcdMakefileEnd


### PR DESCRIPTION
Since everyone should now be running a version of edk2 that expects CFLAGS instead of BUILD_CFLAGS, remove the compatibility code.