### PR TITLE
UPT/Core/FileHook.py: Add the dir_fd parameter to _hookrmdir

### DIFF
--- a/edk2basetools/UPT/Core/FileHook.py
+++ b/edk2basetools/UPT/Core/FileHook.py
@@ -166,7 +166,7 @@ def _hookmkdir(path, mode=0o777):
     else:
         __built_in_mkdir__(path, mode)
 
-def _hookrmdir(path):
+def _hookrmdir(path, dir_fd=None):
     if GlobalData.gRECOVERMGR:
         GlobalData.gRECOVERMGR.bkrmdir(path)
     else:


### PR DESCRIPTION
As of Python 3.3, os.rmdir takes an optional parameter dir_fd. Add it to _hookrmdir to avoid the following error when running pytest:

>   os.rmdir(path, dir_fd=dir_fd)
E   TypeError: _hookrmdir() got an unexpected keyword argument 'dir_fd'