### PR TITLE
FMMT GuidTool Auto Select Config file

### DIFF
--- a/edk2basetools/FMMT/core/GuidTools.py
+++ b/edk2basetools/FMMT/core/GuidTools.py
@@ -110,7 +110,7 @@ class GUIDTools:
         if os.environ['FmmtConfPath']:
             self.tooldef_file = os.path.join(os.environ['FmmtConfPath'], 'FmmtConf.ini')
         else:
-            PathList = os.environ['PATH']
+            PathList = os.environ['PATH'].split(';')
             for CurrentPath in PathList:
                 if os.path.exists(os.path.join(CurrentPath, 'FmmtConf.ini')):
                     self.tooldef_file = os.path.join(CurrentPath, 'FmmtConf.ini')


### PR DESCRIPTION
Currently, Python FMMT tool does not support automatically select FMMTConf.ini file which saves GuidTool settings. This patch support this features.