### PR TITLE
BaseTools: FMMT replace new free space fixing in replace

### DIFF
--- a/edk2basetools/FMMT/core/FvHandler.py
+++ b/edk2basetools/FMMT/core/FvHandler.py
@@ -456,7 +456,7 @@ class FvHandler:
                     # Start free space calculating and moving process.
                     self.ModifyTest(TargetFv.Parent, Needed_Space)
         else:
-            New_Free_Space = self.TargetFfs.Data.Size - self.NewFfs.Data.Size
+            New_Free_Space = self.TargetFfs.Data.Size + len(self.TargetFfs.Data.PadData) - self.NewFfs.Data.Size - len(self.NewFfs.Data.PadData)
             # If TargetFv already have free space, move the new free space into it.
             if TargetFv.Data.Free_Space:
                 TargetFv.Child[-1].Data.Data += b'\xff' * New_Free_Space


### PR DESCRIPTION
In FMMT replace function, when newffs size <= targetffs size, the new free space is calculated wrong as loss the pad data delta size. That will cause invalid binary generated.
This patch fixes this issue.

Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Bob Feng <bob.c.feng@intel.com>