### PR TITLE
Remove Duplicate sets of SkuName and SkuId from allskuset

### DIFF
--- a/edk2basetools/AutoGen/PlatformAutoGen.py
+++ b/edk2basetools/AutoGen/PlatformAutoGen.py
@@ -707,6 +707,8 @@ class PlatformAutoGen(AutoGen):
         self._DynamicPcdList.extend(list(OtherPcdArray))
         self._DynamicPcdList.sort()
         allskuset = [(SkuName, Sku.SkuId) for pcd in self._DynamicPcdList for (SkuName, Sku) in pcd.SkuInfoList.items()]
+        # Remove duplicate sets in the list
+        allskuset = list(set(allskuset))
         for pcd in self._DynamicPcdList:
             if len(pcd.SkuInfoList) == 1:
                 for (SkuName, SkuId) in allskuset:


### PR DESCRIPTION
Currently when the platform has many SKUs then allskuset will be having so many duplicate. and while parsing the allskuset will take longer time while passing Pcd.SkuInfoList.
This patch is to eliminate those duplicate entires to reduce the build time