### PR TITLE
Add build package to requirements.publisher.txt

### DIFF
--- a/requirements.publisher.txt
+++ b/requirements.publisher.txt
@@ -1,3 +1,4 @@
+build
 setuptools
 wheel
 twine


### PR DESCRIPTION
The build package is now required to publish packages.