### PR TITLE
Specify py-modules since CI leaves folders around confusing build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,5 +60,8 @@ AmlToC = "edk2basetools.AmlToC.AmlToC:Main"
 
 [tool.setuptools_scm]
 
+[tool.setuptools]
+py-modules = ["edk2basetools"]
+
 [tool.coverage.run]
 include = ["edk2basetools/*"]


### PR DESCRIPTION
Specify the py-modules to be just edk2basetools since the CI process leaves folders around which confuses the build.