### PR TITLE
BaseTools/AutoGen: declare ProcessLibraryConstructorList() for SEC modules

### DIFF
--- a/edk2basetools/AutoGen/GenC.py
+++ b/edk2basetools/AutoGen/GenC.py
@@ -1371,6 +1371,14 @@ def CreateLibraryConstructorCode(Info, AutoGenC, AutoGenH):
     else:
         if Info.ModuleType in [SUP_MODULE_BASE, SUP_MODULE_SEC, SUP_MODULE_USER_DEFINED, SUP_MODULE_HOST_APPLICATION]:
             AutoGenC.Append(gLibraryString[SUP_MODULE_BASE].Replace(Dict))
+            if Info.ModuleType == SUP_MODULE_SEC and Info.AutoGenVersion >= 0x0001001E:
+                AutoGenH.Append(("\n"
+                                 "// ProcessLibraryConstructorList() declared here because SEC has no standard entry point.\n"
+                                 "VOID\n"
+                                 "EFIAPI\n"
+                                 "ProcessLibraryConstructorList (\n"
+                                 "  VOID\n"
+                                 "  );\n"))
         elif Info.ModuleType in SUP_MODULE_SET_PEI:
             AutoGenC.Append(gLibraryString['PEI'].Replace(Dict))
         elif Info.ModuleType in [SUP_MODULE_DXE_CORE, SUP_MODULE_DXE_DRIVER, SUP_MODULE_DXE_SMM_DRIVER, SUP_MODULE_DXE_RUNTIME_DRIVER,


### PR DESCRIPTION
https://bugzilla.tianocore.org/show_bug.cgi?id=991

~~~
Most module types have standardized entry point function prototypes. They
are declared in headers like

- MdePkg/Include/Library/PeiCoreEntryPoint.h
- MdePkg/Include/Library/PeimEntryPoint.h
- MdePkg/Include/Library/DxeCoreEntryPoint.h
- MdePkg/Include/Library/UefiDriverEntryPoint.h
- MdePkg/Include/Library/UefiApplicationEntryPoint.h

These header files also declare matching ProcessLibraryConstructorList()
prototypes.

The SEC module type does not have a standardized entry point prototype
(aka parameter list), therefore no header file like the above ones exists
for SEC. Consequently, no header file *declares*
ProcessLibraryConstructorList() for SEC modules, even though AutoGen
always *defines* ProcessLibraryConstructorList() with the same, empty,
parameter list (i.e., just (VOID)).

The lack of a central declaration is a problem because in SEC code,
ProcessLibraryConstructorList() needs to be called manually, and those
calls need a prototype. Most SEC modules in edk2 get around this by
declaring ProcessLibraryConstructorList() manually, while some others use
an incorrect (PEIM) prototype.

Liming suggested in
<https://bugzilla.tianocore.org/show_bug.cgi?id=991#c2> that AutoGen
provide the declaration as well; implement that in this patch.

Mike suggested that the feature be gated with INF_VERSION, for
compatibility reasons. (INF_VERSION >= 1.30) reflects that the latest
(draft) version of the INF specification, as of this writing, is commit
a31e3c842bee / version 1.29.

For example, if we modify "OvmfPkg/Sec/SecMain.inf" as follows:

> diff --git a/OvmfPkg/Sec/SecMain.inf b/OvmfPkg/Sec/SecMain.inf
> index 3c47a664a95d..dca932a474ee 100644
> --- a/OvmfPkg/Sec/SecMain.inf
> +++ b/OvmfPkg/Sec/SecMain.inf
> @@ -8,7 +8,7 @@
>  ##
>
>  [Defines]
> -  INF_VERSION                    = 0x00010005
> +  INF_VERSION                    = 1.30
>    BASE_NAME                      = SecMain
>    FILE_GUID                      = df1ccef6-f301-4a63-9661-fc6030dcc880
>    MODULE_TYPE                    = SEC

then the patch produces the following difference in
"Build/OvmfX64/NOOPT_GCC5/X64/OvmfPkg/Sec/SecMain/DEBUG/AutoGen.h":

> --- AutoGen.h.orig      2024-02-06 23:10:23.469535345 +0100
> +++ AutoGen.h   2024-02-07 00:00:57.361294055 +0100
> @@ -220,6 +220,13 @@
>
>  // Definition of PCDs used in libraries is in AutoGen.c
>
> +// ProcessLibraryConstructorList() declared here because SEC has no standard entry point.
> +VOID
> +EFIAPI
> +ProcessLibraryConstructorList (
> +  VOID
> +  );
> +
>
>  #ifdef __cplusplus
>  }

which presently (as of edk2 commit edc6681206c1) triggers the following
build error:

> In file included from OvmfPkg/Sec/SecMain.c:14:
> MdePkg/Include/Library/PeimEntryPoint.h:74:1: error: conflicting types for
> ‘ProcessLibraryConstructorList’; have ‘void(void *, const
> EFI_PEI_SERVICES **)’ {aka ‘void(void *, const struct _EFI_PEI_SERVICES
> **)’}
>    74 | ProcessLibraryConstructorList (
>       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> In file included from <command-line>:
> Build/OvmfX64/NOOPT_GCC5/X64/OvmfPkg/Sec/SecMain/DEBUG/AutoGen.h:226:1: note:
> previous declaration of ‘ProcessLibraryConstructorList’ with type
> ‘void(void)’
>   226 | ProcessLibraryConstructorList (
>       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

That's a genuine bug in OvmfPkg that needs to be fixed, but we keep
compatibility with existent SEC modules until/unless they upgrade
INF_VERSION to 1.30+.

Cc: Bob Feng <bob.c.feng@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Yuwei Chen <yuwei.chen@intel.com>
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=991
Suggested-by: Liming Gao <gaoliming@byosoft.com.cn>
Suggested-by: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Laszlo Ersek <lersek@redhat.com>
~~~