### PR TITLE
Fix license classifier: 'BSD+Patent' isn't valid for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: BSD+Patent",
+  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers"


### PR DESCRIPTION
PyPI only accepts "BSD License" and doesn't have any knowledge of the BSD + Patent license. So fix the classifier to just be "BSD License".