### PR TITLE
FMMT Skip empty Lines while parsing FMMTConfig.ini

### DIFF
--- a/edk2basetools/FMMT/core/GuidTools.py
+++ b/edk2basetools/FMMT/core/GuidTools.py
@@ -153,7 +153,7 @@ class GUIDTools:
                 config_data = fd.readlines()
             for line in config_data:
                 try:
-                    if not line.startswith("#"):
+                    if not line.startswith("#") and line.strip():
                         guid, short_name, command = line.split()
                         new_format_guid = struct2stream(ModifyGuidFormat(guid.strip()))
                         self.tooldef[new_format_guid] = GUIDTool(


### PR DESCRIPTION
When the FMMTConf.ini file has empty lines then it used to throw errors GuidTool load error!, this patch is to skip checking for empty lines in the ini file