### PR TITLE
Fix [tools.setuptools] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ AmlToC = "edk2basetools.AmlToC.AmlToC:Main"
 [tool.setuptools_scm]
 
 [tool.setuptools]
-py-modules = ["edk2basetools"]
+packages = ["edk2basetools"]
 
 [tool.coverage.run]
 include = ["edk2basetools/*"]


### PR DESCRIPTION
Fix pyproject.toml: the py-modules line doesn't cause the package to include the edk2basetools module. Switching it to packages fixes this.

Fixes issue #124 